### PR TITLE
fix(core): dist route URL simplification, TAR→ZIP conversion, and KV cache TTL

### DIFF
--- a/packages/core/src/__tests__/repository-filter.test.ts
+++ b/packages/core/src/__tests__/repository-filter.test.ts
@@ -1,0 +1,63 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { matchesPackageFilter } from '../utils/repository-filter';
+
+describe('matchesPackageFilter', () => {
+  it('should return true when filter is null', () => {
+    expect(matchesPackageFilter(null, 'vendor/package')).toBe(true);
+  });
+
+  it('should return true when filter is empty string', () => {
+    expect(matchesPackageFilter('', 'vendor/package')).toBe(true);
+  });
+
+  it('should return true when filter is only whitespace/commas', () => {
+    expect(matchesPackageFilter(' , , ', 'vendor/package')).toBe(true);
+  });
+
+  it('should match exact package name', () => {
+    expect(matchesPackageFilter('vendor/package', 'vendor/package')).toBe(true);
+  });
+
+  it('should not match different package name', () => {
+    expect(matchesPackageFilter('vendor/package', 'vendor/other')).toBe(false);
+  });
+
+  it('should match wildcard vendor/*', () => {
+    expect(matchesPackageFilter('vendor/*', 'vendor/package')).toBe(true);
+    expect(matchesPackageFilter('vendor/*', 'vendor/other')).toBe(true);
+  });
+
+  it('should not match wildcard for different vendor', () => {
+    expect(matchesPackageFilter('vendor/*', 'other/package')).toBe(false);
+  });
+
+  it('should match prefix wildcard', () => {
+    expect(matchesPackageFilter('mirasvit*', 'mirasvit-module')).toBe(true);
+    expect(matchesPackageFilter('mirasvit*', 'mirasvit/foo')).toBe(true);
+  });
+
+  it('should not match prefix wildcard for non-matching prefix', () => {
+    expect(matchesPackageFilter('mirasvit*', 'amasty/foo')).toBe(false);
+  });
+
+  it('should match multiple patterns (comma-separated)', () => {
+    expect(matchesPackageFilter('vendor/a, other/*', 'vendor/a')).toBe(true);
+    expect(matchesPackageFilter('vendor/a, other/*', 'other/b')).toBe(true);
+    expect(matchesPackageFilter('vendor/a, other/*', 'unrelated/x')).toBe(false);
+  });
+
+  it('should be case-insensitive', () => {
+    expect(matchesPackageFilter('Vendor/*', 'vendor/package')).toBe(true);
+    expect(matchesPackageFilter('vendor/*', 'Vendor/Package')).toBe(true);
+  });
+
+  it('should handle whitespace in patterns', () => {
+    expect(matchesPackageFilter('  vendor/a , other/*  ', 'vendor/a')).toBe(true);
+  });
+});

--- a/packages/core/src/__tests__/tar-to-zip.test.ts
+++ b/packages/core/src/__tests__/tar-to-zip.test.ts
@@ -1,0 +1,177 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ensureZipFormat } from '../routes/dist';
+import { zipSync, unzipSync, gzipSync } from 'fflate';
+
+/**
+ * Create a minimal valid TAR archive from a record of filename→content.
+ */
+function createTar(files: Record<string, string>): Uint8Array {
+  const blocks: Uint8Array[] = [];
+
+  for (const [name, content] of Object.entries(files)) {
+    const contentBytes = new TextEncoder().encode(content);
+    const header = new Uint8Array(512);
+
+    // Filename (bytes 0-99)
+    const nameBytes = new TextEncoder().encode(name);
+    header.set(nameBytes.slice(0, 100), 0);
+
+    // File mode (bytes 100-107): 0000644
+    header.set(new TextEncoder().encode('0000644\0'), 100);
+
+    // Owner/group (bytes 108-123): zeros
+    header.set(new TextEncoder().encode('0000000\0'), 108);
+    header.set(new TextEncoder().encode('0000000\0'), 116);
+
+    // File size in octal (bytes 124-135)
+    const sizeOctal = contentBytes.length.toString(8).padStart(11, '0') + '\0';
+    header.set(new TextEncoder().encode(sizeOctal), 124);
+
+    // Modification time (bytes 136-147)
+    const mtime = Math.floor(Date.now() / 1000).toString(8).padStart(11, '0') + '\0';
+    header.set(new TextEncoder().encode(mtime), 136);
+
+    // Type flag (byte 156): '0' = regular file
+    header[156] = 48; // ASCII '0'
+
+    // UStar magic (bytes 257-262)
+    header.set(new TextEncoder().encode('ustar\0'), 257);
+
+    // UStar version (bytes 263-264)
+    header.set(new TextEncoder().encode('00'), 263);
+
+    // Compute checksum (bytes 148-155): sum of all header bytes, treating checksum field as spaces
+    header.set(new TextEncoder().encode('        '), 148); // 8 spaces
+    let checksum = 0;
+    for (let i = 0; i < 512; i++) checksum += header[i];
+    const checksumStr = checksum.toString(8).padStart(6, '0') + '\0 ';
+    header.set(new TextEncoder().encode(checksumStr), 148);
+
+    blocks.push(header);
+
+    // File data padded to 512 bytes
+    const paddedSize = Math.ceil(contentBytes.length / 512) * 512;
+    const dataBlock = new Uint8Array(paddedSize);
+    dataBlock.set(contentBytes);
+    blocks.push(dataBlock);
+  }
+
+  // End-of-archive: two 512-byte zero blocks
+  blocks.push(new Uint8Array(1024));
+
+  const totalSize = blocks.reduce((sum, b) => sum + b.length, 0);
+  const tar = new Uint8Array(totalSize);
+  let offset = 0;
+  for (const block of blocks) {
+    tar.set(block, offset);
+    offset += block.length;
+  }
+  return tar;
+}
+
+describe('ensureZipFormat', () => {
+  it('should pass through ZIP data unchanged', async () => {
+    const originalZip = zipSync({ 'test.txt': new TextEncoder().encode('hello') });
+    const result = await ensureZipFormat(originalZip);
+    expect(result).toEqual(originalZip);
+  });
+
+  it('should convert a TAR archive to ZIP', async () => {
+    const tar = createTar({ 'hello.txt': 'world' });
+    const result = await ensureZipFormat(tar);
+
+    // Verify it's a valid ZIP by unzipping
+    const files = unzipSync(result);
+    expect(files['hello.txt']).toBeDefined();
+    expect(new TextDecoder().decode(files['hello.txt'])).toBe('world');
+  });
+
+  it('should convert a .tar.gz archive to ZIP', async () => {
+    const tar = createTar({ 'pkg/composer.json': '{"name": "test/pkg"}' });
+    // Verify the TAR is valid before gzipping
+    expect(tar.length).toBeGreaterThan(512);
+    const tarGz = gzipSync(tar);
+    // Verify gzip magic
+    expect(tarGz[0]).toBe(0x1f);
+    expect(tarGz[1]).toBe(0x8b);
+
+    const result = await ensureZipFormat(tarGz);
+
+    // Verify ZIP magic
+    expect(result[0]).toBe(0x50); // P
+    expect(result[1]).toBe(0x4B); // K
+    const files = unzipSync(result);
+    expect(files['pkg/composer.json']).toBeDefined();
+    expect(new TextDecoder().decode(files['pkg/composer.json'])).toContain('test/pkg');
+  });
+
+  it('should sanitize path traversal in TAR entries', async () => {
+    const tar = createTar({ '../../etc/passwd': 'root:x:0:0' });
+    const result = await ensureZipFormat(tar);
+
+    const files = unzipSync(result);
+    // Should not have the traversal path
+    expect(files['../../etc/passwd']).toBeUndefined();
+    // Should be sanitized to just 'etc/passwd'
+    expect(files['etc/passwd']).toBeDefined();
+  });
+
+  it('should sanitize backslash traversal in TAR entries', async () => {
+    const tar = createTar({ 'vendor/..\\evil/payload.txt': 'malicious' });
+    const result = await ensureZipFormat(tar);
+
+    const files = unzipSync(result);
+    // Backslash traversal should be neutralized
+    expect(files['vendor/..\\evil/payload.txt']).toBeUndefined();
+    // Should be sanitized
+    const keys = Object.keys(files);
+    for (const key of keys) {
+      expect(key).not.toContain('..');
+    }
+  });
+
+  it('should handle empty TAR archive', async () => {
+    // Just two zero blocks = empty archive
+    const emptyTar = new Uint8Array(1024);
+    // Add ustar magic so it's detected as TAR
+    emptyTar.set(new TextEncoder().encode('ustar\0'), 257);
+
+    const result = await ensureZipFormat(emptyTar);
+    const files = unzipSync(result);
+    expect(Object.keys(files)).toHaveLength(0);
+  });
+
+  it('should handle TAR with multiple files', async () => {
+    const tar = createTar({
+      'src/index.ts': 'export default {}',
+      'package.json': '{"name": "test"}',
+      'README.md': '# Hello',
+    });
+    const result = await ensureZipFormat(tar);
+
+    const files = unzipSync(result);
+    expect(Object.keys(files)).toHaveLength(3);
+    expect(files['src/index.ts']).toBeDefined();
+    expect(files['package.json']).toBeDefined();
+    expect(files['README.md']).toBeDefined();
+  });
+
+  it('should handle Uint8Array input', async () => {
+    const zip = zipSync({ 'a.txt': new TextEncoder().encode('a') });
+    const result = await ensureZipFormat(new Uint8Array(zip));
+    expect(result).toEqual(zip);
+  });
+
+  it('should handle ArrayBuffer input', async () => {
+    const zip = zipSync({ 'a.txt': new TextEncoder().encode('a') });
+    const result = await ensureZipFormat(zip.buffer as ArrayBuffer);
+    // Content should match (may be different Uint8Array instance)
+    expect(new Uint8Array(result)).toEqual(zip);
+  });
+});

--- a/packages/core/src/modules/composer/index.ts
+++ b/packages/core/src/modules/composer/index.ts
@@ -24,7 +24,7 @@ import {
  * These routes MUST stay at root level to maintain Composer protocol compatibility:
  * - /packages.json
  * - /p2/:vendor/:package
- * - /dist/*
+ * - /dists/* (mirror format, matching Private Packagist style)
  */
 export function mountComposerRoutes(app: AppInstance): void {
   const composerAuth = async (c: any, next: any) => {
@@ -44,13 +44,19 @@ export function mountComposerRoutes(app: AppInstance): void {
     return distAuthMiddleware(c, next);
   };
 
-  // GET /dist/m/:vendor/:package/:version - mirror URL format
+  // GET /dists/:vendor/:package/:version/:reference - mirror URL format (Private Packagist style)
+  // Server resolves repository from package name - no repo ID in URL
+  // Reference can be a commit hash or generated reference
+  app.get('/dists/:vendor/:package/:version/:reference', composerAuth, distAuth, distMirrorRoute);
+
+  // Legacy routes for backwards compatibility
+  // GET /dist/m/:vendor/:package/:version - old mirror URL format
   app.get('/dist/m/:vendor/:package/:version', composerAuth, distAuth, distMirrorRoute);
 
-  // GET /dist/:vendor/:package/:version/:reference - lockfile format
+  // GET /dist/:vendor/:package/:version/:reference - lockfile format (legacy)
   app.get('/dist/:vendor/:package/:version/:reference', composerAuth, distAuth, distLockfileRoute);
 
-  // GET /dist/:repo_id/:vendor/:package/:version - repository-specific format
+  // GET /dist/:repo_id/:vendor/:package/:version - repository-specific format (legacy)
   app.get('/dist/:repo_id/:vendor/:package/:version', composerAuth, distAuth, distRoute);
 }
 

--- a/packages/core/src/routes/composer.ts
+++ b/packages/core/src/routes/composer.ts
@@ -172,12 +172,13 @@ export async function packagesJsonRoute(c: Context<ComposerRouteEnv>): Promise<R
   const packagesJson = await buildPackagesJson(c);
 
   // Cache the result (fire-and-forget to avoid blocking on KV rate limits)
+  // TTL of 1 hour ensures cache is refreshed periodically
   const cachingEnabled = await isPackageCachingEnabled(c.env.KV);
   if (cachingEnabled && c.env.KV) {
     c.executionCtx.waitUntil(
       Promise.all([
-        c.env.KV.put(kvKey, JSON.stringify(packagesJson)).catch(() => { }),
-        c.env.KV.put(metadataKey, JSON.stringify({ lastModified: Date.now() })).catch(() => { })
+        c.env.KV.put(kvKey, JSON.stringify(packagesJson), { expirationTtl: 3600 }).catch(() => { }),
+        c.env.KV.put(metadataKey, JSON.stringify({ lastModified: Date.now() }), { expirationTtl: 3600 }).catch(() => { })
       ])
     );
   }
@@ -436,12 +437,13 @@ export async function p2PackageRoute(c: Context<ComposerRouteEnv>): Promise<Resp
     const packageData = buildP2Response(packageName, existingPackages, maxVersions, baseUrl);
 
     // Cache the result (fire-and-forget to avoid blocking on KV rate limits)
+    // TTL of 1 hour ensures cache is refreshed periodically
     const cachingEnabled = await isPackageCachingEnabled(c.env.KV);
     if (cachingEnabled && c.env.KV) {
       c.executionCtx.waitUntil(
         Promise.all([
-          c.env.KV.put(kvKey, JSON.stringify(packageData)).catch(() => { }),
-          c.env.KV.put(metadataKey, JSON.stringify({ lastModified: Date.now() })).catch(() => { })
+          c.env.KV.put(kvKey, JSON.stringify(packageData), { expirationTtl: 3600 }).catch(() => { }),
+          c.env.KV.put(metadataKey, JSON.stringify({ lastModified: Date.now() }), { expirationTtl: 3600 }).catch(() => { })
         ])
       );
     }

--- a/packages/core/src/routes/dist.ts
+++ b/packages/core/src/routes/dist.ts
@@ -1427,8 +1427,15 @@ function convertTarToZip(data: Uint8Array): Uint8Array {
 
     if ((typeFlag === 48 || typeFlag === 0) && size > 0 && name && !name.endsWith('/')) {
       const fileData = data.slice(offset, offset + size);
-      // Sanitize path: strip leading / and ../ segments
-      const safeName = name.replace(/^\/+/, '').replace(/\.\.\//g, '');
+      // Sanitize path: resolve traversal sequences then strip leading /
+      // Use a loop to handle nested evasion patterns like '....//'' → '../'
+      let safeName = name;
+      let prev: string;
+      do {
+        prev = safeName;
+        safeName = safeName.replace(/\.\.\//g, '');
+      } while (safeName !== prev);
+      safeName = safeName.replace(/^\/+/, '');
       if (safeName) {
         files[safeName] = fileData;
       }

--- a/packages/core/src/routes/dist.ts
+++ b/packages/core/src/routes/dist.ts
@@ -1355,27 +1355,34 @@ export async function distRoute(c: Context<DistRouteEnv>): Promise<Response> {
 export const distMirrorRoute = distRoute;
 export const distLockfileRoute = distRoute;
 
+/** Maximum decompressed size: 100 MB (prevents zip/gzip bombs) */
+const MAX_DECOMPRESSED_SIZE = 100 * 1024 * 1024;
+
 /**
  * Detect if binary data is a TAR archive.
- * Checks for ZIP first (to avoid false positives), then gzip, then ustar magic.
+ * Checks for ZIP first (to avoid false positives), then gzip (single layer), then ustar magic.
  */
-function isTarArchive(data: Uint8Array): boolean {
-  if (data.length < 264) return false;
-
+function isTarArchive(data: Uint8Array, depth = 0): boolean {
   // ZIP magic bytes — not a TAR
-  if (data[0] === 0x50 && data[1] === 0x4B && data[2] === 0x03 && data[3] === 0x04) {
+  if (data.length >= 4 && data[0] === 0x50 && data[1] === 0x4B && data[2] === 0x03 && data[3] === 0x04) {
     return false;
   }
 
-  // Gzip magic — decompress first, then check inner TAR
-  if (data[0] === 0x1f && data[1] === 0x8b) {
+  // Gzip magic — decompress one layer only (depth limit prevents recursive bombs)
+  // Check before the length gate since gzipped TARs can be smaller than 264 bytes
+  if (data.length >= 2 && data[0] === 0x1f && data[1] === 0x8b) {
+    if (depth > 0) return false;
     try {
       const decompressed = gunzipSync(data);
-      return isTarArchive(decompressed);
+      if (decompressed.length > MAX_DECOMPRESSED_SIZE) return false;
+      return isTarArchive(decompressed, depth + 1);
     } catch {
       return false;
     }
   }
+
+  // Need at least 264 bytes to check UStar magic at offset 257
+  if (data.length < 264) return false;
 
   // UStar magic at offset 257
   const ustarMagic = String.fromCharCode(...data.slice(257, 263));
@@ -1383,17 +1390,34 @@ function isTarArchive(data: Uint8Array): boolean {
 }
 
 /**
+ * Sanitize a TAR entry path to prevent directory traversal.
+ * Splits on /, removes .., ., and empty segments, then rejoins.
+ */
+function sanitizeTarPath(name: string): string {
+  return name
+    .replace(/\\/g, '/') // normalize backslashes
+    .split('/')
+    .filter(seg => seg !== '..' && seg !== '.' && seg !== '')
+    .join('/');
+}
+
+/**
  * Convert a TAR (or .tar.gz) archive to ZIP format in memory.
  * Handles gzip-compressed input automatically.
+ * Supports PAX extended headers (type 'x') and GNU long filenames (type 'L').
  */
 function convertTarToZip(data: Uint8Array): Uint8Array {
   // Decompress gzip if needed
   if (data[0] === 0x1f && data[1] === 0x8b) {
     data = gunzipSync(data);
+    if (data.length > MAX_DECOMPRESSED_SIZE) {
+      throw new Error(`Decompressed archive exceeds ${MAX_DECOMPRESSED_SIZE} byte limit`);
+    }
   }
 
   const files: Record<string, Uint8Array> = {};
   let offset = 0;
+  let nextLongName: string | null = null; // For GNU long filename (type 'L')
 
   while (offset + 512 <= data.length) {
     // Check for end-of-archive (two consecutive zero blocks)
@@ -1421,21 +1445,50 @@ function convertTarToZip(data: Uint8Array): Uint8Array {
     }
     const size = parseInt(sizeStr, 8) || 0;
 
-    // Type flag (byte 156): '0' or '\0' = regular file
+    // Type flag (byte 156)
     const typeFlag = header[156];
     offset += 512;
 
+    // Handle GNU long filename (type 'L' = 76)
+    if (typeFlag === 76 && size > 0) {
+      const longNameBytes = data.slice(offset, offset + size);
+      let longName = new TextDecoder().decode(longNameBytes);
+      // Strip null terminator if present
+      if (longName.endsWith('\0')) longName = longName.slice(0, -1);
+      nextLongName = longName;
+      offset += Math.ceil(size / 512) * 512;
+      continue;
+    }
+
+    // Handle PAX extended header (type 'x' = 120)
+    if (typeFlag === 120 && size > 0) {
+      const paxBytes = data.slice(offset, offset + size);
+      const paxStr = new TextDecoder().decode(paxBytes);
+      // Parse PAX records for path= entry
+      const pathMatch = paxStr.match(/\d+ path=(.+)\n/);
+      if (pathMatch) {
+        nextLongName = pathMatch[1];
+      }
+      offset += Math.ceil(size / 512) * 512;
+      continue;
+    }
+
+    // Skip PAX global header (type 'g' = 103) and GNU long link (type 'K' = 75)
+    if (typeFlag === 103 || typeFlag === 75) {
+      offset += Math.ceil(size / 512) * 512;
+      continue;
+    }
+
+    // Use long name from previous GNU/PAX entry if available
+    if (nextLongName) {
+      name = nextLongName;
+      nextLongName = null;
+    }
+
+    // Regular file: type '0' (48) or null (0)
     if ((typeFlag === 48 || typeFlag === 0) && size > 0 && name && !name.endsWith('/')) {
       const fileData = data.slice(offset, offset + size);
-      // Sanitize path: resolve traversal sequences then strip leading /
-      // Use a loop to handle nested evasion patterns like '....//'' → '../'
-      let safeName = name;
-      let prev: string;
-      do {
-        prev = safeName;
-        safeName = safeName.replace(/\.\.\//g, '');
-      } while (safeName !== prev);
-      safeName = safeName.replace(/^\/+/, '');
+      const safeName = sanitizeTarPath(name);
       if (safeName) {
         files[safeName] = fileData;
       }
@@ -1460,7 +1513,15 @@ export async function ensureZipFormat(body: ReadableStream | ArrayBuffer | Uint8
     data = new Uint8Array(body);
   } else {
     const response = new Response(body);
-    data = new Uint8Array(await response.arrayBuffer());
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > MAX_DECOMPRESSED_SIZE) {
+      throw new Error(`Archive size ${buffer.byteLength} exceeds ${MAX_DECOMPRESSED_SIZE} byte limit`);
+    }
+    data = new Uint8Array(buffer);
+  }
+
+  if (data.length > MAX_DECOMPRESSED_SIZE) {
+    throw new Error(`Archive size ${data.length} exceeds ${MAX_DECOMPRESSED_SIZE} byte limit`);
   }
 
   if (isTarArchive(data)) {

--- a/packages/core/src/routes/dist.ts
+++ b/packages/core/src/routes/dist.ts
@@ -16,7 +16,7 @@ import { downloadFromSource } from '../utils/download';
 import { decryptCredentials } from '../utils/encryption';
 import { COMPOSER_USER_AGENT } from '@package-broker/shared';
 import { nanoid } from 'nanoid';
-import { unzipSync, strFromU8 } from 'fflate';
+import { unzipSync, strFromU8, zipSync, gunzipSync } from 'fflate';
 import { getLogger } from '../utils/logger';
 import { getAnalytics } from '../utils/analytics';
 import { type AuthContext } from '../middleware/auth';
@@ -1354,3 +1354,111 @@ export async function distRoute(c: Context<DistRouteEnv>): Promise<Response> {
 
 export const distMirrorRoute = distRoute;
 export const distLockfileRoute = distRoute;
+
+/**
+ * Detect if binary data is a TAR archive.
+ * Checks for ZIP first (to avoid false positives), then gzip, then ustar magic.
+ */
+function isTarArchive(data: Uint8Array): boolean {
+  if (data.length < 264) return false;
+
+  // ZIP magic bytes — not a TAR
+  if (data[0] === 0x50 && data[1] === 0x4B && data[2] === 0x03 && data[3] === 0x04) {
+    return false;
+  }
+
+  // Gzip magic — decompress first, then check inner TAR
+  if (data[0] === 0x1f && data[1] === 0x8b) {
+    try {
+      const decompressed = gunzipSync(data);
+      return isTarArchive(decompressed);
+    } catch {
+      return false;
+    }
+  }
+
+  // UStar magic at offset 257
+  const ustarMagic = String.fromCharCode(...data.slice(257, 263));
+  return ustarMagic === 'ustar\x00' || ustarMagic === 'ustar ';
+}
+
+/**
+ * Convert a TAR (or .tar.gz) archive to ZIP format in memory.
+ * Handles gzip-compressed input automatically.
+ */
+function convertTarToZip(data: Uint8Array): Uint8Array {
+  // Decompress gzip if needed
+  if (data[0] === 0x1f && data[1] === 0x8b) {
+    data = gunzipSync(data);
+  }
+
+  const files: Record<string, Uint8Array> = {};
+  let offset = 0;
+
+  while (offset + 512 <= data.length) {
+    // Check for end-of-archive (two consecutive zero blocks)
+    const header = data.slice(offset, offset + 512);
+    if (header.every(b => b === 0)) break;
+
+    // Extract filename (bytes 0-99)
+    let nameEnd = 0;
+    while (nameEnd < 100 && header[nameEnd] !== 0) nameEnd++;
+    let name = new TextDecoder().decode(header.slice(0, nameEnd));
+
+    // UStar prefix (bytes 345-499)
+    if (header[345] !== 0) {
+      let prefixEnd = 345;
+      while (prefixEnd < 500 && header[prefixEnd] !== 0) prefixEnd++;
+      const prefix = new TextDecoder().decode(header.slice(345, prefixEnd));
+      name = prefix + '/' + name;
+    }
+
+    // File size from octal (bytes 124-135)
+    let sizeStr = '';
+    for (let i = 124; i < 136; i++) {
+      if (header[i] === 0 || header[i] === 32) break;
+      sizeStr += String.fromCharCode(header[i]);
+    }
+    const size = parseInt(sizeStr, 8) || 0;
+
+    // Type flag (byte 156): '0' or '\0' = regular file
+    const typeFlag = header[156];
+    offset += 512;
+
+    if ((typeFlag === 48 || typeFlag === 0) && size > 0 && name && !name.endsWith('/')) {
+      const fileData = data.slice(offset, offset + size);
+      // Sanitize path: strip leading / and ../ segments
+      const safeName = name.replace(/^\/+/, '').replace(/\.\.\//g, '');
+      if (safeName) {
+        files[safeName] = fileData;
+      }
+    }
+
+    // Advance past file data (padded to 512-byte boundary)
+    offset += Math.ceil(size / 512) * 512;
+  }
+
+  return zipSync(files);
+}
+
+/**
+ * If the response body is a TAR archive, convert it to ZIP.
+ * Returns the original data if it's already a ZIP.
+ */
+export async function ensureZipFormat(body: ReadableStream | ArrayBuffer | Uint8Array): Promise<Uint8Array> {
+  let data: Uint8Array;
+  if (body instanceof Uint8Array) {
+    data = body;
+  } else if (body instanceof ArrayBuffer) {
+    data = new Uint8Array(body);
+  } else {
+    const response = new Response(body);
+    data = new Uint8Array(await response.arrayBuffer());
+  }
+
+  if (isTarArchive(data)) {
+    return convertTarToZip(data);
+  }
+
+  return data;
+}

--- a/packages/core/src/utils/repository-filter.ts
+++ b/packages/core/src/utils/repository-filter.ts
@@ -1,0 +1,46 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+/**
+ * Check if a package name matches a repository's package_filter.
+ * 
+ * Supports:
+ * - Exact matches: "vendor/package"
+ * - Wildcard patterns: "vendor/*" matches all packages under vendor
+ * - Prefix wildcards: "mirasvit*" matches "mirasvit-module", "mirasvit/foo"
+ * 
+ * @param packageFilter - Comma-separated list of package patterns (e.g., "vendor/*,other/package")
+ * @param packageName - Package name to check (e.g., "vendor/package")
+ * @returns true if package matches any pattern in the filter, or if filter is null/empty
+ */
+export function matchesPackageFilter(packageFilter: string | null, packageName: string): boolean {
+  if (!packageFilter) return true;
+  
+  const patterns = packageFilter
+    .split(',')
+    .map((p: string) => p.trim().toLowerCase())
+    .filter((p: string) => p.length > 0);
+  
+  if (patterns.length === 0) return true;
+
+  const pkgLower = packageName.toLowerCase();
+  
+  return patterns.some((pattern: string) => {
+    if (pattern.endsWith('/*')) {
+      // Wildcard pattern: "vendor/*" matches "vendor/anything"
+      const prefix = pattern.slice(0, -1); // "vendor/"
+      return pkgLower.startsWith(prefix);
+    }
+    if (pattern.endsWith('*')) {
+      // Prefix wildcard: "mirasvit*" matches "mirasvit-module", "mirasvit/foo"
+      const prefix = pattern.slice(0, -1);
+      return pkgLower.startsWith(prefix);
+    }
+    // Exact match
+    return pkgLower === pattern;
+  });
+}
+


### PR DESCRIPTION
## Summary

- Simplify dist URLs to match Private Packagist style (removes redundant path segments)
- Convert TAR archives to ZIP format for Composer compatibility
- Add TTL to KV cache entries to prevent stale cached package data

## Test plan

- [ ] Verify dist URLs resolve correctly for Composer `composer require` commands
- [ ] Verify `.tar.gz` packages are served as `.zip` for Composer compatibility
- [ ] Verify KV cache entries expire after TTL (no stale data)