### PR TITLE
feat(core): add token scope service for per-token package filtering

### DIFF
--- a/packages/core/src/__tests__/token-scoping.test.ts
+++ b/packages/core/src/__tests__/token-scoping.test.ts
@@ -76,6 +76,14 @@ describe('TokenScopeService', () => {
     expect(service.getAuthorizedRepoIds()).toEqual(['repo-1', 'repo-2']);
   });
 
+  it('should deny canAccessPackage when only repo scopes exist (no patterns)', () => {
+    const service = new TokenScopeService([
+      { scope_type: 'repository', scope_value: 'repo-1' },
+    ]);
+    // canAccessPackage only checks pattern scopes, not repo scopes
+    expect(service.canAccessPackage('vendor/pkg')).toBe(false);
+  });
+
   it('should return null for package patterns when unscoped', () => {
     const service = new TokenScopeService([]);
     expect(service.getPackagePatterns()).toBeNull();

--- a/packages/core/src/__tests__/token-scoping.test.ts
+++ b/packages/core/src/__tests__/token-scoping.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { TokenScopeService } from '../services/TokenScopeService';
+import { matchesPackageFilter } from '../utils/package-filter';
+
+describe('matchesPackageFilter', () => {
+  it('should match exact package name', () => {
+    expect(matchesPackageFilter('vendor/pkg', 'vendor/pkg')).toBe(true);
+    expect(matchesPackageFilter('vendor/pkg', 'vendor/other')).toBe(false);
+  });
+
+  it('should match vendor/* glob pattern', () => {
+    expect(matchesPackageFilter('vendor/pkg-a', 'vendor/*')).toBe(true);
+    expect(matchesPackageFilter('vendor/pkg-b', 'vendor/*')).toBe(true);
+    expect(matchesPackageFilter('other/pkg', 'vendor/*')).toBe(false);
+  });
+
+  it('should match comma-separated patterns', () => {
+    expect(matchesPackageFilter('vendor/pkg', 'vendor/*, other/pkg')).toBe(true);
+    expect(matchesPackageFilter('other/pkg', 'vendor/*, other/pkg')).toBe(true);
+    expect(matchesPackageFilter('unknown/pkg', 'vendor/*, other/pkg')).toBe(false);
+  });
+
+  it('should be case-insensitive', () => {
+    expect(matchesPackageFilter('Vendor/Pkg', 'vendor/*')).toBe(true);
+    expect(matchesPackageFilter('vendor/pkg', 'Vendor/*')).toBe(true);
+  });
+});
+
+describe('TokenScopeService', () => {
+  it('should allow all packages when token has no scopes (legacy)', () => {
+    const service = new TokenScopeService([]);
+    expect(service.canAccessPackage('vendor/pkg')).toBe(true);
+    expect(service.canAccessPackageFromRepo('vendor/pkg', 'repo-123')).toBe(true);
+  });
+
+  it('should filter packages by pattern scope', () => {
+    const service = new TokenScopeService([
+      { scope_type: 'package_pattern', scope_value: 'fastwhitecat/*' },
+    ]);
+    expect(service.canAccessPackage('fastwhitecat/module-a')).toBe(true);
+    expect(service.canAccessPackage('other/module-b')).toBe(false);
+  });
+
+  it('should filter packages by repository scope', () => {
+    const service = new TokenScopeService([
+      { scope_type: 'repository', scope_value: 'repo-abc123' },
+    ]);
+    expect(service.canAccessPackageFromRepo('vendor/pkg', 'repo-abc123')).toBe(true);
+    expect(service.canAccessPackageFromRepo('vendor/pkg', 'repo-other')).toBe(false);
+  });
+
+  it('should allow access when either repo or pattern matches', () => {
+    const service = new TokenScopeService([
+      { scope_type: 'repository', scope_value: 'repo-1' },
+      { scope_type: 'package_pattern', scope_value: 'vendor/*' },
+    ]);
+    // Matches via repo scope
+    expect(service.canAccessPackageFromRepo('unknown/pkg', 'repo-1')).toBe(true);
+    // Matches via pattern scope
+    expect(service.canAccessPackageFromRepo('vendor/pkg', 'repo-other')).toBe(true);
+    // Matches neither
+    expect(service.canAccessPackageFromRepo('unknown/pkg', 'repo-other')).toBe(false);
+  });
+
+  it('should return null for authorized repo IDs when unscoped', () => {
+    const service = new TokenScopeService([]);
+    expect(service.getAuthorizedRepoIds()).toBeNull();
+  });
+
+  it('should return authorized repo IDs when scoped', () => {
+    const service = new TokenScopeService([
+      { scope_type: 'repository', scope_value: 'repo-1' },
+      { scope_type: 'repository', scope_value: 'repo-2' },
+      { scope_type: 'package_pattern', scope_value: 'vendor/*' },
+    ]);
+    expect(service.getAuthorizedRepoIds()).toEqual(['repo-1', 'repo-2']);
+  });
+
+  it('should return null for package patterns when unscoped', () => {
+    const service = new TokenScopeService([]);
+    expect(service.getPackagePatterns()).toBeNull();
+  });
+
+  it('should return package patterns when scoped', () => {
+    const service = new TokenScopeService([
+      { scope_type: 'package_pattern', scope_value: 'vendor/*' },
+      { scope_type: 'package_pattern', scope_value: 'other/specific-pkg' },
+    ]);
+    expect(service.getPackagePatterns()).toEqual(['vendor/*', 'other/specific-pkg']);
+  });
+});

--- a/packages/core/src/__tests__/token-scoping.test.ts
+++ b/packages/core/src/__tests__/token-scoping.test.ts
@@ -20,6 +20,13 @@ describe('matchesPackageFilter', () => {
     expect(matchesPackageFilter('unknown/pkg', 'vendor/*, other/pkg')).toBe(false);
   });
 
+  it('should not match bare * or vendor* without slash', () => {
+    // 'vendor*' should NOT match — only 'vendor/*' is valid glob
+    expect(matchesPackageFilter('vendor/pkg', 'vendor*')).toBe(false);
+    // bare '*' should not match anything (not a valid glob)
+    expect(matchesPackageFilter('anything/pkg', '*')).toBe(false);
+  });
+
   it('should be case-insensitive', () => {
     expect(matchesPackageFilter('Vendor/Pkg', 'vendor/*')).toBe(true);
     expect(matchesPackageFilter('vendor/pkg', 'Vendor/*')).toBe(true);

--- a/packages/core/src/middleware/auth.ts
+++ b/packages/core/src/middleware/auth.ts
@@ -8,6 +8,16 @@ import { tokens, tokenScopes } from '../db/schema';
 import { eq } from 'drizzle-orm';
 import { TokenScopeService } from '../services/TokenScopeService';
 
+async function loadTokenScopes(db: DatabasePort, tokenId: string): Promise<TokenScopeService> {
+  const scopeRows = await db
+    .select({ scope_type: tokenScopes.scope_type, scope_value: tokenScopes.scope_value })
+    .from(tokenScopes)
+    .where(eq(tokenScopes.token_id, tokenId));
+  return new TokenScopeService(
+    scopeRows as { scope_type: 'repository' | 'package_pattern'; scope_value: string }[]
+  );
+}
+
 export interface AuthContext {
   tokenId: string;
   tokenDescription: string;
@@ -209,14 +219,7 @@ export async function distAuthMiddleware(
     return c.json({ error: 'Too Many Requests', message: 'Rate limit exceeded' }, 429);
   }
 
-  // Load token scopes for access control
-  const scopeRows = await db
-    .select({ scope_type: tokenScopes.scope_type, scope_value: tokenScopes.scope_value })
-    .from(tokenScopes)
-    .where(eq(tokenScopes.token_id, tokenRecord.id));
-  const scopeService = new TokenScopeService(
-    scopeRows as { scope_type: 'repository' | 'package_pattern'; scope_value: string }[]
-  );
+  const scopeService = await loadTokenScopes(db, tokenRecord.id);
 
   // Attach token info to context
   c.set('auth', {
@@ -347,14 +350,7 @@ export async function authMiddleware(
     );
   }
 
-  // Load token scopes for access control
-  const scopeRows = await db
-    .select({ scope_type: tokenScopes.scope_type, scope_value: tokenScopes.scope_value })
-    .from(tokenScopes)
-    .where(eq(tokenScopes.token_id, tokenRecord.id));
-  const scopeService = new TokenScopeService(
-    scopeRows as { scope_type: 'repository' | 'package_pattern'; scope_value: string }[]
-  );
+  const scopeService = await loadTokenScopes(db, tokenRecord.id);
 
   // Attach token info to context
   c.set('auth', {

--- a/packages/core/src/middleware/auth.ts
+++ b/packages/core/src/middleware/auth.ts
@@ -8,13 +8,16 @@ import { tokens, tokenScopes } from '../db/schema';
 import { eq } from 'drizzle-orm';
 import { TokenScopeService } from '../services/TokenScopeService';
 
+const VALID_SCOPE_TYPES = new Set(['repository', 'package_pattern']);
+
 async function loadTokenScopes(db: DatabasePort, tokenId: string): Promise<TokenScopeService> {
   const scopeRows = await db
     .select({ scope_type: tokenScopes.scope_type, scope_value: tokenScopes.scope_value })
     .from(tokenScopes)
     .where(eq(tokenScopes.token_id, tokenId));
+  const validScopes = scopeRows.filter((row) => VALID_SCOPE_TYPES.has(row.scope_type));
   return new TokenScopeService(
-    scopeRows as { scope_type: 'repository' | 'package_pattern'; scope_value: string }[]
+    validScopes as { scope_type: 'repository' | 'package_pattern'; scope_value: string }[]
   );
 }
 

--- a/packages/core/src/middleware/auth.ts
+++ b/packages/core/src/middleware/auth.ts
@@ -15,7 +15,7 @@ async function loadTokenScopes(db: DatabasePort, tokenId: string): Promise<Token
     .select({ scope_type: tokenScopes.scope_type, scope_value: tokenScopes.scope_value })
     .from(tokenScopes)
     .where(eq(tokenScopes.token_id, tokenId));
-  const validScopes = scopeRows.filter((row) => VALID_SCOPE_TYPES.has(row.scope_type));
+  const validScopes = scopeRows.filter((row: { scope_type: string; scope_value: string }) => VALID_SCOPE_TYPES.has(row.scope_type));
   return new TokenScopeService(
     validScopes as { scope_type: 'repository' | 'package_pattern'; scope_value: string }[]
   );

--- a/packages/core/src/middleware/auth.ts
+++ b/packages/core/src/middleware/auth.ts
@@ -4,13 +4,15 @@ import type { Context } from 'hono';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex } from '@noble/hashes/utils.js';
 import type { DatabasePort } from '../ports';
-import { tokens } from '../db/schema';
+import { tokens, tokenScopes } from '../db/schema';
 import { eq } from 'drizzle-orm';
+import { TokenScopeService } from '../services/TokenScopeService';
 
 export interface AuthContext {
   tokenId: string;
   tokenDescription: string;
   tokenPermissions: 'readonly' | 'write';
+  scopeService: TokenScopeService;
 }
 
 /**
@@ -207,11 +209,21 @@ export async function distAuthMiddleware(
     return c.json({ error: 'Too Many Requests', message: 'Rate limit exceeded' }, 429);
   }
 
+  // Load token scopes for access control
+  const scopeRows = await db
+    .select({ scope_type: tokenScopes.scope_type, scope_value: tokenScopes.scope_value })
+    .from(tokenScopes)
+    .where(eq(tokenScopes.token_id, tokenRecord.id));
+  const scopeService = new TokenScopeService(
+    scopeRows as { scope_type: 'repository' | 'package_pattern'; scope_value: string }[]
+  );
+
   // Attach token info to context
   c.set('auth', {
     tokenId: tokenRecord.id,
     tokenDescription: tokenRecord.description,
     tokenPermissions: (tokenRecord.permissions || 'readonly') as 'readonly' | 'write',
+    scopeService,
   });
 
   // Update last_used_at (non-blocking)
@@ -335,11 +347,21 @@ export async function authMiddleware(
     );
   }
 
+  // Load token scopes for access control
+  const scopeRows = await db
+    .select({ scope_type: tokenScopes.scope_type, scope_value: tokenScopes.scope_value })
+    .from(tokenScopes)
+    .where(eq(tokenScopes.token_id, tokenRecord.id));
+  const scopeService = new TokenScopeService(
+    scopeRows as { scope_type: 'repository' | 'package_pattern'; scope_value: string }[]
+  );
+
   // Attach token info to context
   c.set('auth', {
     tokenId: tokenRecord.id,
     tokenDescription: tokenRecord.description,
     tokenPermissions: (tokenRecord.permissions || 'readonly') as 'readonly' | 'write',
+    scopeService,
   });
 
   // Track token usage analytics

--- a/packages/core/src/services/TokenScopeService.ts
+++ b/packages/core/src/services/TokenScopeService.ts
@@ -1,0 +1,55 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+import { matchesPackageFilter } from '../utils/package-filter';
+
+export interface TokenScope {
+  scope_type: 'repository' | 'package_pattern';
+  scope_value: string;
+}
+
+export class TokenScopeService {
+  private scopes: TokenScope[];
+  private isUnscoped: boolean;
+
+  constructor(scopes: TokenScope[]) {
+    this.scopes = scopes;
+    this.isUnscoped = scopes.length === 0;
+  }
+
+  /** Legacy tokens with no scopes can access everything */
+  canAccessPackage(packageName: string): boolean {
+    if (this.isUnscoped) return true;
+    return this.scopes.some(
+      (s) => s.scope_type === 'package_pattern' && matchesPackageFilter(packageName, s.scope_value)
+    );
+  }
+
+  canAccessPackageFromRepo(packageName: string, repoId: string): boolean {
+    if (this.isUnscoped) return true;
+    const repoMatch = this.scopes.some(
+      (s) => s.scope_type === 'repository' && s.scope_value === repoId
+    );
+    const patternMatch = this.scopes.some(
+      (s) => s.scope_type === 'package_pattern' && matchesPackageFilter(packageName, s.scope_value)
+    );
+    return repoMatch || patternMatch;
+  }
+
+  getAuthorizedRepoIds(): string[] | null {
+    if (this.isUnscoped) return null; // null = all repos
+    return this.scopes
+      .filter((s) => s.scope_type === 'repository')
+      .map((s) => s.scope_value);
+  }
+
+  getPackagePatterns(): string[] | null {
+    if (this.isUnscoped) return null;
+    return this.scopes
+      .filter((s) => s.scope_type === 'package_pattern')
+      .map((s) => s.scope_value);
+  }
+}

--- a/packages/core/src/utils/package-filter.ts
+++ b/packages/core/src/utils/package-filter.ts
@@ -1,0 +1,23 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+/**
+ * Check if a package name matches a filter pattern.
+ * Supports glob-style patterns: 'vendor/*' matches 'vendor/anything'.
+ * Comma-separated patterns: 'vendor/*,other/pkg' matches either.
+ */
+export function matchesPackageFilter(packageName: string, filter: string): boolean {
+  const patterns = filter.split(',').map((p) => p.trim().toLowerCase());
+  const pkgLower = packageName.toLowerCase();
+
+  return patterns.some((pattern) => {
+    if (pattern.endsWith('/*') || pattern.endsWith('*')) {
+      const prefix = pattern.replace(/\*$/, '');
+      return pkgLower.startsWith(prefix);
+    }
+    return pkgLower === pattern;
+  });
+}

--- a/packages/core/src/utils/package-filter.ts
+++ b/packages/core/src/utils/package-filter.ts
@@ -14,8 +14,9 @@ export function matchesPackageFilter(packageName: string, filter: string): boole
   const pkgLower = packageName.toLowerCase();
 
   return patterns.some((pattern) => {
-    if (pattern.endsWith('/*') || pattern.endsWith('*')) {
-      const prefix = pattern.replace(/\*$/, '');
+    // Only support vendor/* style globs (must have / before *)
+    if (pattern.endsWith('/*')) {
+      const prefix = pattern.slice(0, -1); // 'vendor/' from 'vendor/*'
       return pkgLower.startsWith(prefix);
     }
     return pkgLower === pattern;


### PR DESCRIPTION
## Summary

- Adds `TokenScopeService` for checking package/repo access per token
- Extracts `matchesPackageFilter` to reusable `utils/package-filter.ts`
- Updates both `authMiddleware` and `distAuthMiddleware` to load token scopes via shared `loadTokenScopes` helper
- Legacy tokens with no scopes continue to see everything (backwards compatible)
- 13 unit tests covering pattern matching, repo scoping, and edge cases

Closes #101 (partial — service + middleware, UI integration in future PR)

## Test plan

- [ ] `npm test` — all 175 tests pass
- [ ] `npx tsc --noEmit` — clean typecheck
- [ ] Verify unscoped tokens still access all packages
- [ ] Verify scoped tokens filter by pattern and repo ID