### PR TITLE
feat(core): add organization and tenant schema (#102)

### DIFF
--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -160,7 +160,7 @@ export const organizations = sqliteTable(
     slug: text('slug').notNull(),
     owner_user_id: text('owner_user_id')
       .notNull()
-      .references(() => users.id),
+      .references(() => users.id, { onDelete: 'restrict' }),
     created_at: integer('created_at').notNull(),
   },
   (table) => ({

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -15,6 +15,7 @@ export const repositories = sqliteTable(
     error_message: text('error_message'),
     last_synced_at: integer('last_synced_at'),
     created_at: integer('created_at').notNull(),
+    org_id: text('org_id').references(() => organizations.id),
   },
   (table) => ({
     statusIdx: index('idx_repositories_status').on(table.status),
@@ -36,6 +37,8 @@ export const tokens = sqliteTable(
     created_at: integer('created_at').notNull(),
     expires_at: integer('expires_at'),
     last_used_at: integer('last_used_at'),
+    tenant_id: text('tenant_id').references(() => tenants.id),
+    org_id: text('org_id').references(() => organizations.id),
   },
   (table) => ({
     tokenHashIdx: index('idx_tokens_token_hash').on(table.token_hash),
@@ -188,19 +191,19 @@ export const organizationMembers = sqliteTable(
   'organization_members',
   {
     id: text('id').primaryKey(),
-    organization_id: text('organization_id')
+    org_id: text('org_id')
       .notNull()
       .references(() => organizations.id, { onDelete: 'cascade' }),
     user_id: text('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
-    role: text('role').notNull().default('member'),
+    role: text('role').notNull().default('member'), // 'owner' | 'admin' | 'member'
     created_at: integer('created_at').notNull(),
   },
   (table) => ({
-    orgIdIdx: index('idx_org_members_org_id').on(table.organization_id),
+    orgIdIdx: index('idx_org_members_org_id').on(table.org_id),
     userIdIdx: index('idx_org_members_user_id').on(table.user_id),
-    orgUserUnique: unique('org_members_org_user_unique').on(table.organization_id, table.user_id),
+    orgUserUnique: unique('org_members_org_user_unique').on(table.org_id, table.user_id),
   })
 );
 

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -148,5 +148,82 @@ export const users = sqliteTable(
   })
 );
 
+// Organizations table
+export const organizations = sqliteTable(
+  'organizations',
+  {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    slug: text('slug').notNull(),
+    owner_user_id: text('owner_user_id')
+      .notNull()
+      .references(() => users.id),
+    created_at: integer('created_at').notNull(),
+  },
+  (table) => ({
+    slugUnique: unique('organizations_slug_unique').on(table.slug),
+  })
+);
+
+// Tenants table
+export const tenants = sqliteTable(
+  'tenants',
+  {
+    id: text('id').primaryKey(),
+    org_id: text('org_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    slug: text('slug').notNull(),
+    created_at: integer('created_at').notNull(),
+  },
+  (table) => ({
+    orgIdIdx: index('idx_tenants_org_id').on(table.org_id),
+    orgSlugUnique: unique('tenants_org_slug_unique').on(table.org_id, table.slug),
+  })
+);
+
+// Organization members table
+export const organizationMembers = sqliteTable(
+  'organization_members',
+  {
+    id: text('id').primaryKey(),
+    organization_id: text('organization_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    user_id: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    role: text('role').notNull().default('member'),
+    created_at: integer('created_at').notNull(),
+  },
+  (table) => ({
+    orgIdIdx: index('idx_org_members_org_id').on(table.organization_id),
+    userIdIdx: index('idx_org_members_user_id').on(table.user_id),
+    orgUserUnique: unique('org_members_org_user_unique').on(table.organization_id, table.user_id),
+  })
+);
+
+// Tenant packages table
+export const tenantPackages = sqliteTable(
+  'tenant_packages',
+  {
+    id: text('id').primaryKey(),
+    tenant_id: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id, { onDelete: 'cascade' }),
+    package_pattern: text('package_pattern').notNull(),
+    access_level: text('access_level').notNull().default('read'),
+    created_at: integer('created_at').notNull(),
+  },
+  (table) => ({
+    tenantIdIdx: index('idx_tenant_packages_tenant_id').on(table.tenant_id),
+    tenantPatternUnique: unique('tenant_packages_tenant_pattern_unique').on(
+      table.tenant_id,
+      table.package_pattern
+    ),
+  })
+);
+
 // NO activity_log table - use Cloudflare Workers logs for debugging
 // Workers logs are limited to last X entries and don't require database storage

--- a/packages/main/migrations/0009_organizations.sql
+++ b/packages/main/migrations/0009_organizations.sql
@@ -1,0 +1,45 @@
+CREATE TABLE organizations (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL,
+  owner_user_id TEXT NOT NULL REFERENCES users(id),
+  created_at INTEGER NOT NULL,
+  CONSTRAINT organizations_slug_unique UNIQUE(slug)
+);
+
+CREATE TABLE tenants (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  CONSTRAINT tenants_org_slug_unique UNIQUE(org_id, slug)
+);
+
+CREATE TABLE organization_members (
+  id TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'member',
+  created_at INTEGER NOT NULL,
+  CONSTRAINT org_members_org_user_unique UNIQUE(organization_id, user_id)
+);
+
+CREATE TABLE tenant_packages (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  package_pattern TEXT NOT NULL,
+  access_level TEXT NOT NULL DEFAULT 'read',
+  created_at INTEGER NOT NULL,
+  CONSTRAINT tenant_packages_tenant_pattern_unique UNIQUE(tenant_id, package_pattern)
+);
+
+CREATE INDEX idx_tenants_org_id ON tenants(org_id);
+CREATE INDEX idx_org_members_org_id ON organization_members(organization_id);
+CREATE INDEX idx_org_members_user_id ON organization_members(user_id);
+CREATE INDEX idx_tenant_packages_tenant_id ON tenant_packages(tenant_id);
+
+-- Add org references to existing tables
+ALTER TABLE tokens ADD COLUMN tenant_id TEXT REFERENCES tenants(id);
+ALTER TABLE tokens ADD COLUMN organization_id TEXT REFERENCES organizations(id);
+ALTER TABLE repositories ADD COLUMN org_id TEXT REFERENCES organizations(id);

--- a/packages/main/migrations/0009_organizations.sql
+++ b/packages/main/migrations/0009_organizations.sql
@@ -2,7 +2,7 @@ CREATE TABLE organizations (
   id TEXT PRIMARY KEY,
   name TEXT NOT NULL,
   slug TEXT NOT NULL,
-  owner_user_id TEXT NOT NULL REFERENCES users(id),
+  owner_user_id TEXT NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
   created_at INTEGER NOT NULL,
   CONSTRAINT organizations_slug_unique UNIQUE(slug)
 );
@@ -43,3 +43,7 @@ CREATE INDEX idx_tenant_packages_tenant_id ON tenant_packages(tenant_id);
 ALTER TABLE tokens ADD COLUMN tenant_id TEXT REFERENCES tenants(id);
 ALTER TABLE tokens ADD COLUMN org_id TEXT REFERENCES organizations(id);
 ALTER TABLE repositories ADD COLUMN org_id TEXT REFERENCES organizations(id);
+
+CREATE INDEX idx_tokens_tenant_id ON tokens(tenant_id);
+CREATE INDEX idx_tokens_org_id ON tokens(org_id);
+CREATE INDEX idx_repositories_org_id ON repositories(org_id);

--- a/packages/main/migrations/0009_organizations.sql
+++ b/packages/main/migrations/0009_organizations.sql
@@ -18,28 +18,28 @@ CREATE TABLE tenants (
 
 CREATE TABLE organization_members (
   id TEXT PRIMARY KEY,
-  organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  org_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
   user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  role TEXT NOT NULL DEFAULT 'member',
+  role TEXT NOT NULL DEFAULT 'member' CHECK(role IN ('owner', 'admin', 'member')),
   created_at INTEGER NOT NULL,
-  CONSTRAINT org_members_org_user_unique UNIQUE(organization_id, user_id)
+  CONSTRAINT org_members_org_user_unique UNIQUE(org_id, user_id)
 );
 
 CREATE TABLE tenant_packages (
   id TEXT PRIMARY KEY,
   tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
   package_pattern TEXT NOT NULL,
-  access_level TEXT NOT NULL DEFAULT 'read',
+  access_level TEXT NOT NULL DEFAULT 'read' CHECK(access_level IN ('read', 'write')),
   created_at INTEGER NOT NULL,
   CONSTRAINT tenant_packages_tenant_pattern_unique UNIQUE(tenant_id, package_pattern)
 );
 
 CREATE INDEX idx_tenants_org_id ON tenants(org_id);
-CREATE INDEX idx_org_members_org_id ON organization_members(organization_id);
+CREATE INDEX idx_org_members_org_id ON organization_members(org_id);
 CREATE INDEX idx_org_members_user_id ON organization_members(user_id);
 CREATE INDEX idx_tenant_packages_tenant_id ON tenant_packages(tenant_id);
 
 -- Add org references to existing tables
 ALTER TABLE tokens ADD COLUMN tenant_id TEXT REFERENCES tenants(id);
-ALTER TABLE tokens ADD COLUMN organization_id TEXT REFERENCES organizations(id);
+ALTER TABLE tokens ADD COLUMN org_id TEXT REFERENCES organizations(id);
 ALTER TABLE repositories ADD COLUMN org_id TEXT REFERENCES organizations(id);


### PR DESCRIPTION
## Summary

- Adds migration `0009_organizations.sql` with 4 new tables: `organizations`, `tenants`, `organization_members`, `tenant_packages`
- Adds `org_id`/`tenant_id` FK columns to existing `tokens` and `repositories` tables
- Adds Drizzle ORM schema definitions matching the migration
- Includes CHECK constraints for `role` and `access_level`, proper indexes on all FK columns, and ON DELETE RESTRICT on owner FK

## Test plan

- [ ] Migration applies cleanly on fresh database
- [ ] `npm run typecheck` passes across all packages
- [ ] `npx vitest run` — all 181 tests pass
- [ ] Verify constraint names follow project convention

Closes #102 (partial — schema only, CRUD API in next PR)