### PR TITLE
feat(core): add organization and tenant CRUD API (#102)

### DIFF
--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -19,6 +19,8 @@ import packagesModule from './modules/packages';
 import artifactsModule from './modules/artifacts';
 import { statsModule, settingsModule } from './modules/admin';
 import { mountComposerRoutes } from './modules/composer';
+import organizationsModule from './modules/organizations';
+import tenantsModule from './modules/tenants';
 import { getPackageStatsRouteDef } from './modules/admin/admin.routes';
 import { getPackageStats } from './modules/admin/admin.handlers';
 
@@ -200,6 +202,16 @@ export function createApp(options?: {
     protectedRoutes.route('/packages', packagesModule);
     protectedRoutes.route('/artifacts', artifactsModule);
     protectedRoutes.route('/import', importModule);
+    protectedRoutes.route('/organizations', organizationsModule);
+
+    // Mount tenants under organizations with org_id middleware
+    const orgTenantsRoutes = new OpenAPIHono<{ Bindings: AppBindings; Variables: AppVariables }>();
+    orgTenantsRoutes.use('*', async (c: any, next: any) => {
+        c.set('org_id', c.req.param('org_id'));
+        await next();
+    });
+    orgTenantsRoutes.route('/', tenantsModule);
+    protectedRoutes.route('/organizations/:org_id/tenants', orgTenantsRoutes);
     
     // Admin module - split into separate modules to avoid route collisions
     protectedRoutes.route('/stats', statsModule);

--- a/packages/core/src/modules/organizations/index.ts
+++ b/packages/core/src/modules/organizations/index.ts
@@ -1,0 +1,27 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+import { OpenAPIHono } from '@hono/zod-openapi';
+import type { AppBindings, AppVariables } from '../../factory';
+import * as routes from './organizations.routes';
+import * as handlers from './organizations.handlers';
+
+const organizationsModule = new OpenAPIHono<{ Bindings: AppBindings; Variables: AppVariables }>();
+
+// Organization CRUD
+organizationsModule.openapi(routes.listOrganizationsRouteDef, handlers.listOrganizations as any);
+organizationsModule.openapi(routes.createOrganizationRouteDef, handlers.createOrganization as any);
+organizationsModule.openapi(routes.getOrganizationRouteDef, handlers.getOrganization as any);
+organizationsModule.openapi(routes.updateOrganizationRouteDef, handlers.updateOrganization as any);
+organizationsModule.openapi(routes.deleteOrganizationRouteDef, handlers.deleteOrganization as any);
+
+// Organization members
+organizationsModule.openapi(routes.listMembersRouteDef, handlers.listMembers as any);
+organizationsModule.openapi(routes.addMemberRouteDef, handlers.addMember as any);
+organizationsModule.openapi(routes.updateMemberRouteDef, handlers.updateMember as any);
+organizationsModule.openapi(routes.removeMemberRouteDef, handlers.removeMember as any);
+
+export default organizationsModule;

--- a/packages/core/src/modules/organizations/organizations.handlers.ts
+++ b/packages/core/src/modules/organizations/organizations.handlers.ts
@@ -19,8 +19,6 @@ interface OrgRouteEnv {
   };
 }
 
-type OrgRole = 'owner' | 'admin' | 'member';
-
 async function getMembership(
   db: DatabasePort,
   orgId: string,

--- a/packages/core/src/modules/organizations/organizations.handlers.ts
+++ b/packages/core/src/modules/organizations/organizations.handlers.ts
@@ -1,0 +1,366 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+import type { OpenAPIContext } from '../../types/openapi';
+import type { DatabasePort } from '../../ports';
+import { organizations, organizationMembers, users } from '../../db/schema';
+import { eq, and, inArray } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+
+interface OrgRouteEnv {
+  Bindings: Record<string, unknown>;
+  Variables: {
+    database: DatabasePort;
+    requestId?: string;
+    session?: { userId: string; email: string };
+  };
+}
+
+type OrgRole = 'owner' | 'admin' | 'member';
+
+async function getMembership(
+  db: DatabasePort,
+  orgId: string,
+  userId: string
+): Promise<{ id: string; org_id: string; user_id: string; role: string; created_at: number } | undefined> {
+  const [member] = await db
+    .select()
+    .from(organizationMembers)
+    .where(and(eq(organizationMembers.org_id, orgId), eq(organizationMembers.user_id, userId)))
+    .limit(1);
+  return member;
+}
+
+function canManageMembers(role: string): boolean {
+  return role === 'owner' || role === 'admin';
+}
+
+export async function listOrganizations(c: OpenAPIContext<OrgRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+
+  const memberships = await db
+    .select({ org_id: organizationMembers.org_id })
+    .from(organizationMembers)
+    .where(eq(organizationMembers.user_id, session.userId));
+
+  if (memberships.length === 0) {
+    return c.json([]);
+  }
+
+  const orgIds = memberships.map((m: { org_id: string }) => m.org_id);
+  const userOrgs = await db.select().from(organizations).where(inArray(organizations.id, orgIds));
+
+  return c.json(
+    userOrgs.map((org: typeof organizations.$inferSelect) => ({
+      id: org.id,
+      name: org.name,
+      slug: org.slug,
+      owner_user_id: org.owner_user_id,
+      created_at: org.created_at,
+    }))
+  );
+}
+
+export async function createOrganization(c: OpenAPIContext<OrgRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const validated = c.req.valid('json');
+
+  const name = validated.name.trim();
+  const slug = validated.slug.trim().toLowerCase();
+
+  // Check slug uniqueness
+  const [existing] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.slug, slug))
+    .limit(1);
+
+  if (existing) {
+    return c.json({ error: 'Conflict', message: 'Organization slug is already taken' }, 409);
+  }
+
+  const orgId = nanoid();
+  const now = Math.floor(Date.now() / 1000);
+
+  await db.insert(organizations).values({
+    id: orgId,
+    name,
+    slug,
+    owner_user_id: session.userId,
+    created_at: now,
+  });
+
+  // Add the creator as owner member
+  await db.insert(organizationMembers).values({
+    id: nanoid(),
+    org_id: orgId,
+    user_id: session.userId,
+    role: 'owner',
+    created_at: now,
+  });
+
+  return c.json(
+    {
+      id: orgId,
+      name,
+      slug,
+      owner_user_id: session.userId,
+      created_at: now,
+    },
+    201
+  );
+}
+
+export async function getOrganization(c: OpenAPIContext<OrgRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const { id } = c.req.valid('param');
+
+  const [org] = await db.select().from(organizations).where(eq(organizations.id, id)).limit(1);
+  if (!org) {
+    return c.json({ error: 'Not Found', message: 'Organization not found' }, 404);
+  }
+
+  const membership = await getMembership(db, id, session.userId);
+  if (!membership) {
+    return c.json({ error: 'Forbidden', message: 'You are not a member of this organization' }, 403);
+  }
+
+  return c.json({
+    id: org.id,
+    name: org.name,
+    slug: org.slug,
+    owner_user_id: org.owner_user_id,
+    created_at: org.created_at,
+  });
+}
+
+export async function updateOrganization(c: OpenAPIContext<OrgRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const { id } = c.req.valid('param');
+  const validated = c.req.valid('json');
+
+  const [org] = await db.select().from(organizations).where(eq(organizations.id, id)).limit(1);
+  if (!org) {
+    return c.json({ error: 'Not Found', message: 'Organization not found' }, 404);
+  }
+
+  const membership = await getMembership(db, id, session.userId);
+  if (!membership || !canManageMembers(membership.role)) {
+    return c.json({ error: 'Forbidden', message: 'Requires owner or admin role' }, 403);
+  }
+
+  const updateData: Partial<typeof organizations.$inferInsert> = {};
+  if (validated.name !== undefined) {
+    updateData.name = validated.name.trim();
+  }
+
+  if (Object.keys(updateData).length > 0) {
+    await db.update(organizations).set(updateData).where(eq(organizations.id, id));
+  }
+
+  const [updated] = await db.select().from(organizations).where(eq(organizations.id, id)).limit(1);
+
+  return c.json({
+    id: updated.id,
+    name: updated.name,
+    slug: updated.slug,
+    owner_user_id: updated.owner_user_id,
+    created_at: updated.created_at,
+  });
+}
+
+export async function deleteOrganization(c: OpenAPIContext<OrgRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const { id } = c.req.valid('param');
+
+  const [org] = await db.select().from(organizations).where(eq(organizations.id, id)).limit(1);
+  if (!org) {
+    return c.json({ error: 'Not Found', message: 'Organization not found' }, 404);
+  }
+
+  if (org.owner_user_id !== session.userId) {
+    return c.json({ error: 'Forbidden', message: 'Only the owner can delete the organization' }, 403);
+  }
+
+  await db.delete(organizations).where(eq(organizations.id, id));
+
+  return c.json({ message: 'Organization deleted' });
+}
+
+export async function listMembers(c: OpenAPIContext<OrgRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const { id } = c.req.valid('param');
+
+  const [org] = await db.select({ id: organizations.id }).from(organizations).where(eq(organizations.id, id)).limit(1);
+  if (!org) {
+    return c.json({ error: 'Not Found', message: 'Organization not found' }, 404);
+  }
+
+  const membership = await getMembership(db, id, session.userId);
+  if (!membership) {
+    return c.json({ error: 'Forbidden', message: 'You are not a member of this organization' }, 403);
+  }
+
+  const members = await db
+    .select()
+    .from(organizationMembers)
+    .where(eq(organizationMembers.org_id, id));
+
+  return c.json(
+    members.map((m: typeof organizationMembers.$inferSelect) => ({
+      id: m.id,
+      org_id: m.org_id,
+      user_id: m.user_id,
+      role: m.role,
+      created_at: m.created_at,
+    }))
+  );
+}
+
+export async function addMember(c: OpenAPIContext<OrgRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const { id } = c.req.valid('param');
+  const validated = c.req.valid('json');
+
+  const [org] = await db.select({ id: organizations.id }).from(organizations).where(eq(organizations.id, id)).limit(1);
+  if (!org) {
+    return c.json({ error: 'Not Found', message: 'Organization not found' }, 404);
+  }
+
+  const membership = await getMembership(db, id, session.userId);
+  if (!membership || !canManageMembers(membership.role)) {
+    return c.json({ error: 'Forbidden', message: 'Requires owner or admin role' }, 403);
+  }
+
+  // Verify the target user exists
+  const [targetUser] = await db.select({ id: users.id }).from(users).where(eq(users.id, validated.user_id)).limit(1);
+  if (!targetUser) {
+    return c.json({ error: 'Not Found', message: 'User not found' }, 404);
+  }
+
+  // Check if already a member
+  const existingMembership = await getMembership(db, id, validated.user_id);
+  if (existingMembership) {
+    return c.json({ error: 'Conflict', message: 'User is already a member of this organization' }, 409);
+  }
+
+  const memberId = nanoid();
+  const now = Math.floor(Date.now() / 1000);
+
+  await db.insert(organizationMembers).values({
+    id: memberId,
+    org_id: id,
+    user_id: validated.user_id,
+    role: validated.role,
+    created_at: now,
+  });
+
+  return c.json(
+    {
+      id: memberId,
+      org_id: id,
+      user_id: validated.user_id,
+      role: validated.role,
+      created_at: now,
+    },
+    201
+  );
+}
+
+export async function updateMember(c: OpenAPIContext<OrgRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const { id, user_id } = c.req.valid('param');
+  const validated = c.req.valid('json');
+
+  const [org] = await db.select().from(organizations).where(eq(organizations.id, id)).limit(1);
+  if (!org) {
+    return c.json({ error: 'Not Found', message: 'Organization not found' }, 404);
+  }
+
+  const callerMembership = await getMembership(db, id, session.userId);
+  if (!callerMembership || !canManageMembers(callerMembership.role)) {
+    return c.json({ error: 'Forbidden', message: 'Requires owner or admin role' }, 403);
+  }
+
+  const targetMembership = await getMembership(db, id, user_id);
+  if (!targetMembership) {
+    return c.json({ error: 'Not Found', message: 'Member not found' }, 404);
+  }
+
+  // Cannot change the owner's role
+  if (targetMembership.role === 'owner') {
+    return c.json({ error: 'Forbidden', message: 'Cannot change the owner role' }, 403);
+  }
+
+  // Only owner can change admin roles (promote to or demote from admin)
+  if ((targetMembership.role === 'admin' || validated.role === 'admin') && callerMembership.role !== 'owner') {
+    return c.json({ error: 'Forbidden', message: 'Only the owner can change admin roles' }, 403);
+  }
+
+  await db
+    .update(organizationMembers)
+    .set({ role: validated.role })
+    .where(and(eq(organizationMembers.org_id, id), eq(organizationMembers.user_id, user_id)));
+
+  const [updated] = await db
+    .select()
+    .from(organizationMembers)
+    .where(and(eq(organizationMembers.org_id, id), eq(organizationMembers.user_id, user_id)))
+    .limit(1);
+
+  return c.json({
+    id: updated.id,
+    org_id: updated.org_id,
+    user_id: updated.user_id,
+    role: updated.role,
+    created_at: updated.created_at,
+  });
+}
+
+export async function removeMember(c: OpenAPIContext<OrgRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const { id, user_id } = c.req.valid('param');
+
+  const [org] = await db.select().from(organizations).where(eq(organizations.id, id)).limit(1);
+  if (!org) {
+    return c.json({ error: 'Not Found', message: 'Organization not found' }, 404);
+  }
+
+  const callerMembership = await getMembership(db, id, session.userId);
+  if (!callerMembership || !canManageMembers(callerMembership.role)) {
+    return c.json({ error: 'Forbidden', message: 'Requires owner or admin role' }, 403);
+  }
+
+  const targetMembership = await getMembership(db, id, user_id);
+  if (!targetMembership) {
+    return c.json({ error: 'Not Found', message: 'Member not found' }, 404);
+  }
+
+  // Cannot remove the owner
+  if (targetMembership.role === 'owner') {
+    return c.json({ error: 'Forbidden', message: 'Cannot remove the organization owner' }, 403);
+  }
+
+  // Admins cannot remove other admins (only owner can)
+  if (targetMembership.role === 'admin' && callerMembership.role !== 'owner') {
+    return c.json({ error: 'Forbidden', message: 'Only the owner can remove admins' }, 403);
+  }
+
+  await db
+    .delete(organizationMembers)
+    .where(and(eq(organizationMembers.org_id, id), eq(organizationMembers.user_id, user_id)));
+
+  return c.json({ message: 'Member removed' });
+}

--- a/packages/core/src/modules/organizations/organizations.routes.ts
+++ b/packages/core/src/modules/organizations/organizations.routes.ts
@@ -1,0 +1,287 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+import { createRoute, z } from '@hono/zod-openapi';
+import { errorResponseSchema } from '@package-broker/shared';
+
+const slugPattern = /^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$/;
+
+const organizationResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  owner_user_id: z.string(),
+  created_at: z.number(),
+});
+
+const organizationMemberResponseSchema = z.object({
+  id: z.string(),
+  org_id: z.string(),
+  user_id: z.string(),
+  role: z.enum(['owner', 'admin', 'member']),
+  created_at: z.number(),
+});
+
+const createOrganizationSchema = z.object({
+  name: z.string().min(1).max(100).openapi({ example: 'My Organization' }),
+  slug: z.string().min(3).max(63).regex(slugPattern, 'Slug must be lowercase alphanumeric with hyphens, 3-63 chars').openapi({ example: 'my-org' }),
+});
+
+const updateOrganizationSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+});
+
+const addMemberSchema = z.object({
+  user_id: z.string().min(1),
+  role: z.enum(['admin', 'member']).default('member'),
+});
+
+const updateMemberSchema = z.object({
+  role: z.enum(['admin', 'member']),
+});
+
+const idParam = z.object({
+  id: z.string().openapi({ param: { name: 'id', in: 'path' } }),
+});
+
+const orgMemberParams = z.object({
+  id: z.string().openapi({ param: { name: 'id', in: 'path' } }),
+  user_id: z.string().openapi({ param: { name: 'user_id', in: 'path' } }),
+});
+
+// Route paths are relative to module mount at /api/organizations
+export const listOrganizationsRouteDef = createRoute({
+  method: 'get',
+  path: '/',
+  summary: 'List organizations',
+  description: 'List organizations the current user belongs to',
+  security: [{ Bearer: [] }],
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.array(organizationResponseSchema) } },
+      description: 'List of organizations',
+    },
+  },
+  tags: ['Organizations'],
+});
+
+export const createOrganizationRouteDef = createRoute({
+  method: 'post',
+  path: '/',
+  summary: 'Create organization',
+  description: 'Create a new organization. The current user becomes the owner.',
+  security: [{ Bearer: [] }],
+  request: {
+    body: { content: { 'application/json': { schema: createOrganizationSchema } } },
+  },
+  responses: {
+    201: {
+      content: { 'application/json': { schema: organizationResponseSchema } },
+      description: 'Organization created',
+    },
+    400: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Invalid request',
+    },
+    409: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Slug already taken',
+    },
+  },
+  tags: ['Organizations'],
+});
+
+export const getOrganizationRouteDef = createRoute({
+  method: 'get',
+  path: '/{id}',
+  summary: 'Get organization',
+  description: 'Get organization details',
+  security: [{ Bearer: [] }],
+  request: { params: idParam },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: organizationResponseSchema } },
+      description: 'Organization details',
+    },
+    403: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Not a member',
+    },
+    404: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Organization not found',
+    },
+  },
+  tags: ['Organizations'],
+});
+
+export const updateOrganizationRouteDef = createRoute({
+  method: 'patch',
+  path: '/{id}',
+  summary: 'Update organization',
+  description: 'Update organization name. Requires owner or admin role.',
+  security: [{ Bearer: [] }],
+  request: {
+    params: idParam,
+    body: { content: { 'application/json': { schema: updateOrganizationSchema } } },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: organizationResponseSchema } },
+      description: 'Organization updated',
+    },
+    403: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Insufficient permissions',
+    },
+    404: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Organization not found',
+    },
+  },
+  tags: ['Organizations'],
+});
+
+export const deleteOrganizationRouteDef = createRoute({
+  method: 'delete',
+  path: '/{id}',
+  summary: 'Delete organization',
+  description: 'Delete an organization. Requires owner role.',
+  security: [{ Bearer: [] }],
+  request: { params: idParam },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.object({ message: z.string() }) } },
+      description: 'Organization deleted',
+    },
+    403: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Only the owner can delete',
+    },
+    404: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Organization not found',
+    },
+  },
+  tags: ['Organizations'],
+});
+
+export const listMembersRouteDef = createRoute({
+  method: 'get',
+  path: '/{id}/members',
+  summary: 'List organization members',
+  description: 'List all members of an organization',
+  security: [{ Bearer: [] }],
+  request: { params: idParam },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.array(organizationMemberResponseSchema) } },
+      description: 'List of members',
+    },
+    403: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Not a member',
+    },
+    404: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Organization not found',
+    },
+  },
+  tags: ['Organizations'],
+});
+
+export const addMemberRouteDef = createRoute({
+  method: 'post',
+  path: '/{id}/members',
+  summary: 'Add member to organization',
+  description: 'Add a user as a member. Requires owner or admin role.',
+  security: [{ Bearer: [] }],
+  request: {
+    params: idParam,
+    body: { content: { 'application/json': { schema: addMemberSchema } } },
+  },
+  responses: {
+    201: {
+      content: { 'application/json': { schema: organizationMemberResponseSchema } },
+      description: 'Member added',
+    },
+    400: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Invalid request',
+    },
+    403: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Insufficient permissions',
+    },
+    404: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Organization or user not found',
+    },
+    409: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'User is already a member',
+    },
+  },
+  tags: ['Organizations'],
+});
+
+export const updateMemberRouteDef = createRoute({
+  method: 'patch',
+  path: '/{id}/members/{user_id}',
+  summary: 'Update member role',
+  description: 'Change a member role. Requires owner or admin role.',
+  security: [{ Bearer: [] }],
+  request: {
+    params: orgMemberParams,
+    body: { content: { 'application/json': { schema: updateMemberSchema } } },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: organizationMemberResponseSchema } },
+      description: 'Member updated',
+    },
+    403: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Insufficient permissions',
+    },
+    404: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Member not found',
+    },
+  },
+  tags: ['Organizations'],
+});
+
+export const removeMemberRouteDef = createRoute({
+  method: 'delete',
+  path: '/{id}/members/{user_id}',
+  summary: 'Remove member from organization',
+  description: 'Remove a member. Requires owner or admin role. Cannot remove the owner.',
+  security: [{ Bearer: [] }],
+  request: { params: orgMemberParams },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.object({ message: z.string() }) } },
+      description: 'Member removed',
+    },
+    403: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Insufficient permissions',
+    },
+    404: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Member not found',
+    },
+  },
+  tags: ['Organizations'],
+});
+
+export {
+  createOrganizationSchema,
+  updateOrganizationSchema,
+  addMemberSchema,
+  updateMemberSchema,
+};

--- a/packages/core/src/modules/tenants/index.ts
+++ b/packages/core/src/modules/tenants/index.ts
@@ -1,0 +1,26 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+import { OpenAPIHono } from '@hono/zod-openapi';
+import type { AppBindings, AppVariables } from '../../factory';
+import * as routes from './tenants.routes';
+import * as handlers from './tenants.handlers';
+
+const tenantsModule = new OpenAPIHono<{ Bindings: AppBindings; Variables: AppVariables }>();
+
+// Tenant CRUD
+tenantsModule.openapi(routes.listTenantsRouteDef, handlers.listTenants as any);
+tenantsModule.openapi(routes.createTenantRouteDef, handlers.createTenant as any);
+tenantsModule.openapi(routes.getTenantRouteDef, handlers.getTenant as any);
+tenantsModule.openapi(routes.updateTenantRouteDef, handlers.updateTenant as any);
+tenantsModule.openapi(routes.deleteTenantRouteDef, handlers.deleteTenant as any);
+
+// Tenant package patterns
+tenantsModule.openapi(routes.listTenantPackagesRouteDef, handlers.listTenantPackages as any);
+tenantsModule.openapi(routes.addTenantPackageRouteDef, handlers.addTenantPackage as any);
+tenantsModule.openapi(routes.removeTenantPackageRouteDef, handlers.removeTenantPackage as any);
+
+export default tenantsModule;

--- a/packages/core/src/modules/tenants/tenants.handlers.ts
+++ b/packages/core/src/modules/tenants/tenants.handlers.ts
@@ -1,0 +1,352 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+import type { OpenAPIContext } from '../../types/openapi';
+import type { DatabasePort } from '../../ports';
+import { tenants, tenantPackages, organizationMembers } from '../../db/schema';
+import { eq, and } from 'drizzle-orm';
+import { HTTPException } from 'hono/http-exception';
+import { nanoid } from 'nanoid';
+
+interface TenantRouteEnv {
+  Bindings: Record<string, unknown>;
+  Variables: {
+    database: DatabasePort;
+    requestId?: string;
+    session?: { userId: string; email: string };
+    org_id?: string;
+  };
+}
+
+async function getOrgMembership(
+  db: DatabasePort,
+  orgId: string,
+  userId: string
+): Promise<{ role: string } | undefined> {
+  const [member] = await db
+    .select({ role: organizationMembers.role })
+    .from(organizationMembers)
+    .where(and(eq(organizationMembers.org_id, orgId), eq(organizationMembers.user_id, userId)))
+    .limit(1);
+  return member;
+}
+
+function canManage(role: string): boolean {
+  return role === 'owner' || role === 'admin';
+}
+
+function requireOrgId(c: OpenAPIContext<TenantRouteEnv>): string {
+  // org_id comes from the parent route parameter set by middleware
+  const orgId = c.get('org_id') as string | undefined;
+  if (!orgId) {
+    throw new HTTPException(500, { message: 'Internal configuration error' });
+  }
+  return orgId;
+}
+
+export async function listTenants(c: OpenAPIContext<TenantRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const orgId = requireOrgId(c);
+
+  const membership = await getOrgMembership(db, orgId, session.userId);
+  if (!membership) {
+    return c.json({ error: 'Forbidden', message: 'You are not a member of this organization' }, 403);
+  }
+
+  const orgTenants = await db.select().from(tenants).where(eq(tenants.org_id, orgId));
+
+  return c.json(
+    orgTenants.map((t: typeof tenants.$inferSelect) => ({
+      id: t.id,
+      org_id: t.org_id,
+      name: t.name,
+      slug: t.slug,
+      created_at: t.created_at,
+    }))
+  );
+}
+
+export async function createTenant(c: OpenAPIContext<TenantRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const orgId = requireOrgId(c);
+  const validated = c.req.valid('json');
+
+  const membership = await getOrgMembership(db, orgId, session.userId);
+  if (!membership || !canManage(membership.role)) {
+    return c.json({ error: 'Forbidden', message: 'Requires owner or admin role' }, 403);
+  }
+
+  const name = validated.name.trim();
+  const slug = validated.slug.trim().toLowerCase();
+
+  // Check slug uniqueness within org
+  const [existing] = await db
+    .select({ id: tenants.id })
+    .from(tenants)
+    .where(and(eq(tenants.org_id, orgId), eq(tenants.slug, slug)))
+    .limit(1);
+
+  if (existing) {
+    return c.json({ error: 'Conflict', message: 'Tenant slug is already taken in this organization' }, 409);
+  }
+
+  const tenantId = nanoid();
+  const now = Math.floor(Date.now() / 1000);
+
+  await db.insert(tenants).values({
+    id: tenantId,
+    org_id: orgId,
+    name,
+    slug,
+    created_at: now,
+  });
+
+  return c.json(
+    {
+      id: tenantId,
+      org_id: orgId,
+      name,
+      slug,
+      created_at: now,
+    },
+    201
+  );
+}
+
+export async function getTenant(c: OpenAPIContext<TenantRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const orgId = requireOrgId(c);
+  const { id } = c.req.valid('param');
+
+  const membership = await getOrgMembership(db, orgId, session.userId);
+  if (!membership) {
+    return c.json({ error: 'Forbidden', message: 'You are not a member of this organization' }, 403);
+  }
+
+  const [tenant] = await db
+    .select()
+    .from(tenants)
+    .where(and(eq(tenants.id, id), eq(tenants.org_id, orgId)))
+    .limit(1);
+
+  if (!tenant) {
+    return c.json({ error: 'Not Found', message: 'Tenant not found' }, 404);
+  }
+
+  return c.json({
+    id: tenant.id,
+    org_id: tenant.org_id,
+    name: tenant.name,
+    slug: tenant.slug,
+    created_at: tenant.created_at,
+  });
+}
+
+export async function updateTenant(c: OpenAPIContext<TenantRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const orgId = requireOrgId(c);
+  const { id } = c.req.valid('param');
+  const validated = c.req.valid('json');
+
+  const membership = await getOrgMembership(db, orgId, session.userId);
+  if (!membership || !canManage(membership.role)) {
+    return c.json({ error: 'Forbidden', message: 'Requires owner or admin role' }, 403);
+  }
+
+  const [tenant] = await db
+    .select()
+    .from(tenants)
+    .where(and(eq(tenants.id, id), eq(tenants.org_id, orgId)))
+    .limit(1);
+
+  if (!tenant) {
+    return c.json({ error: 'Not Found', message: 'Tenant not found' }, 404);
+  }
+
+  const updateData: Partial<typeof tenants.$inferInsert> = {};
+  if (validated.name !== undefined) {
+    updateData.name = validated.name.trim();
+  }
+
+  if (Object.keys(updateData).length > 0) {
+    await db.update(tenants).set(updateData).where(eq(tenants.id, id));
+  }
+
+  const [updated] = await db.select().from(tenants).where(eq(tenants.id, id)).limit(1);
+
+  return c.json({
+    id: updated.id,
+    org_id: updated.org_id,
+    name: updated.name,
+    slug: updated.slug,
+    created_at: updated.created_at,
+  });
+}
+
+export async function deleteTenant(c: OpenAPIContext<TenantRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const orgId = requireOrgId(c);
+  const { id } = c.req.valid('param');
+
+  const membership = await getOrgMembership(db, orgId, session.userId);
+  if (!membership || !canManage(membership.role)) {
+    return c.json({ error: 'Forbidden', message: 'Requires owner or admin role' }, 403);
+  }
+
+  const [tenant] = await db
+    .select()
+    .from(tenants)
+    .where(and(eq(tenants.id, id), eq(tenants.org_id, orgId)))
+    .limit(1);
+
+  if (!tenant) {
+    return c.json({ error: 'Not Found', message: 'Tenant not found' }, 404);
+  }
+
+  await db.delete(tenants).where(and(eq(tenants.id, id), eq(tenants.org_id, orgId)));
+
+  return c.json({ message: 'Tenant deleted' });
+}
+
+// Tenant package patterns
+export async function listTenantPackages(c: OpenAPIContext<TenantRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const orgId = requireOrgId(c);
+  const { id } = c.req.valid('param');
+
+  const membership = await getOrgMembership(db, orgId, session.userId);
+  if (!membership) {
+    return c.json({ error: 'Forbidden', message: 'You are not a member of this organization' }, 403);
+  }
+
+  // Verify tenant belongs to org
+  const [tenant] = await db
+    .select({ id: tenants.id })
+    .from(tenants)
+    .where(and(eq(tenants.id, id), eq(tenants.org_id, orgId)))
+    .limit(1);
+
+  if (!tenant) {
+    return c.json({ error: 'Not Found', message: 'Tenant not found' }, 404);
+  }
+
+  const patterns = await db
+    .select()
+    .from(tenantPackages)
+    .where(eq(tenantPackages.tenant_id, id));
+
+  return c.json(
+    patterns.map((p: typeof tenantPackages.$inferSelect) => ({
+      id: p.id,
+      tenant_id: p.tenant_id,
+      package_pattern: p.package_pattern,
+      access_level: p.access_level,
+      created_at: p.created_at,
+    }))
+  );
+}
+
+export async function addTenantPackage(c: OpenAPIContext<TenantRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const orgId = requireOrgId(c);
+  const { id } = c.req.valid('param');
+  const validated = c.req.valid('json');
+
+  const membership = await getOrgMembership(db, orgId, session.userId);
+  if (!membership || !canManage(membership.role)) {
+    return c.json({ error: 'Forbidden', message: 'Requires owner or admin role' }, 403);
+  }
+
+  // Verify tenant belongs to org
+  const [tenant] = await db
+    .select({ id: tenants.id })
+    .from(tenants)
+    .where(and(eq(tenants.id, id), eq(tenants.org_id, orgId)))
+    .limit(1);
+
+  if (!tenant) {
+    return c.json({ error: 'Not Found', message: 'Tenant not found' }, 404);
+  }
+
+  const pattern = validated.package_pattern.trim();
+
+  // Check uniqueness (pattern format already validated by Zod schema)
+  const [existing] = await db
+    .select({ id: tenantPackages.id })
+    .from(tenantPackages)
+    .where(and(eq(tenantPackages.tenant_id, id), eq(tenantPackages.package_pattern, pattern)))
+    .limit(1);
+
+  if (existing) {
+    return c.json({ error: 'Conflict', message: 'Package pattern already exists for this tenant' }, 409);
+  }
+
+  const pkgId = nanoid();
+  const now = Math.floor(Date.now() / 1000);
+
+  await db.insert(tenantPackages).values({
+    id: pkgId,
+    tenant_id: id,
+    package_pattern: pattern,
+    access_level: validated.access_level,
+    created_at: now,
+  });
+
+  return c.json(
+    {
+      id: pkgId,
+      tenant_id: id,
+      package_pattern: pattern,
+      access_level: validated.access_level,
+      created_at: now,
+    },
+    201
+  );
+}
+
+export async function removeTenantPackage(c: OpenAPIContext<TenantRouteEnv>): Promise<Response> {
+  const db = c.get('database');
+  const session = c.get('session') as { userId: string; email: string };
+  const orgId = requireOrgId(c);
+  const { id, package_id } = c.req.valid('param');
+
+  const membership = await getOrgMembership(db, orgId, session.userId);
+  if (!membership || !canManage(membership.role)) {
+    return c.json({ error: 'Forbidden', message: 'Requires owner or admin role' }, 403);
+  }
+
+  // Verify tenant belongs to org
+  const [tenant] = await db
+    .select({ id: tenants.id })
+    .from(tenants)
+    .where(and(eq(tenants.id, id), eq(tenants.org_id, orgId)))
+    .limit(1);
+
+  if (!tenant) {
+    return c.json({ error: 'Not Found', message: 'Tenant not found' }, 404);
+  }
+
+  const [pkg] = await db
+    .select()
+    .from(tenantPackages)
+    .where(and(eq(tenantPackages.id, package_id), eq(tenantPackages.tenant_id, id)))
+    .limit(1);
+
+  if (!pkg) {
+    return c.json({ error: 'Not Found', message: 'Package pattern not found' }, 404);
+  }
+
+  await db.delete(tenantPackages).where(eq(tenantPackages.id, package_id));
+
+  return c.json({ message: 'Package pattern removed' });
+}

--- a/packages/core/src/modules/tenants/tenants.routes.ts
+++ b/packages/core/src/modules/tenants/tenants.routes.ts
@@ -41,22 +41,8 @@ const addTenantPackageSchema = z.object({
   access_level: z.enum(['read', 'write']).default('read'),
 });
 
-const orgIdParam = z.object({
-  org_id: z.string().openapi({ param: { name: 'org_id', in: 'path' } }),
-});
-
-const tenantParams = z.object({
-  org_id: z.string().openapi({ param: { name: 'org_id', in: 'path' } }),
-  id: z.string().openapi({ param: { name: 'id', in: 'path' } }),
-});
-
-const tenantPackageParams = z.object({
-  org_id: z.string().openapi({ param: { name: 'org_id', in: 'path' } }),
-  id: z.string().openapi({ param: { name: 'id', in: 'path' } }),
-  package_id: z.string().openapi({ param: { name: 'package_id', in: 'path' } }),
-});
-
 // Route paths are relative to module mount at /api/organizations/:org_id/tenants
+// org_id is injected via middleware in factory.ts, not declared as a route param
 export const listTenantsRouteDef = createRoute({
   method: 'get',
   path: '/',

--- a/packages/core/src/modules/tenants/tenants.routes.ts
+++ b/packages/core/src/modules/tenants/tenants.routes.ts
@@ -1,0 +1,261 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+import { createRoute, z } from '@hono/zod-openapi';
+import { errorResponseSchema } from '@package-broker/shared';
+
+const slugPattern = /^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$/;
+
+const tenantResponseSchema = z.object({
+  id: z.string(),
+  org_id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  created_at: z.number(),
+});
+
+const tenantPackageResponseSchema = z.object({
+  id: z.string(),
+  tenant_id: z.string(),
+  package_pattern: z.string(),
+  access_level: z.enum(['read', 'write']),
+  created_at: z.number(),
+});
+
+const createTenantSchema = z.object({
+  name: z.string().min(1).max(100).openapi({ example: 'Production' }),
+  slug: z.string().min(3).max(63).regex(slugPattern, 'Slug must be lowercase alphanumeric with hyphens, 3-63 chars').openapi({ example: 'production' }),
+});
+
+const updateTenantSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+});
+
+const packagePatternRegex = /^[a-z0-9]([a-z0-9._-]*[a-z0-9])?\/((\*)|([a-z0-9]([a-z0-9._-]*[a-z0-9])?))$/;
+
+const addTenantPackageSchema = z.object({
+  package_pattern: z.string().min(3).max(255).regex(packagePatternRegex, 'Must be vendor/package or vendor/* format (lowercase)').openapi({ example: 'vendor/*' }),
+  access_level: z.enum(['read', 'write']).default('read'),
+});
+
+const orgIdParam = z.object({
+  org_id: z.string().openapi({ param: { name: 'org_id', in: 'path' } }),
+});
+
+const tenantParams = z.object({
+  org_id: z.string().openapi({ param: { name: 'org_id', in: 'path' } }),
+  id: z.string().openapi({ param: { name: 'id', in: 'path' } }),
+});
+
+const tenantPackageParams = z.object({
+  org_id: z.string().openapi({ param: { name: 'org_id', in: 'path' } }),
+  id: z.string().openapi({ param: { name: 'id', in: 'path' } }),
+  package_id: z.string().openapi({ param: { name: 'package_id', in: 'path' } }),
+});
+
+// Route paths are relative to module mount at /api/organizations/:org_id/tenants
+export const listTenantsRouteDef = createRoute({
+  method: 'get',
+  path: '/',
+  summary: 'List tenants',
+  description: 'List all tenants in the organization',
+  security: [{ Bearer: [] }],
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.array(tenantResponseSchema) } },
+      description: 'List of tenants',
+    },
+    403: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Not a member',
+    },
+  },
+  tags: ['Tenants'],
+});
+
+export const createTenantRouteDef = createRoute({
+  method: 'post',
+  path: '/',
+  summary: 'Create tenant',
+  description: 'Create a new tenant in the organization. Requires owner or admin role.',
+  security: [{ Bearer: [] }],
+  request: {
+    body: { content: { 'application/json': { schema: createTenantSchema } } },
+  },
+  responses: {
+    201: {
+      content: { 'application/json': { schema: tenantResponseSchema } },
+      description: 'Tenant created',
+    },
+    400: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Invalid request',
+    },
+    403: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Insufficient permissions',
+    },
+    409: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Slug already taken in this organization',
+    },
+  },
+  tags: ['Tenants'],
+});
+
+export const getTenantRouteDef = createRoute({
+  method: 'get',
+  path: '/{id}',
+  summary: 'Get tenant',
+  description: 'Get tenant details',
+  security: [{ Bearer: [] }],
+  request: { params: z.object({ id: z.string().openapi({ param: { name: 'id', in: 'path' } }) }) },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: tenantResponseSchema } },
+      description: 'Tenant details',
+    },
+    404: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Tenant not found',
+    },
+  },
+  tags: ['Tenants'],
+});
+
+export const updateTenantRouteDef = createRoute({
+  method: 'patch',
+  path: '/{id}',
+  summary: 'Update tenant',
+  description: 'Update tenant name. Requires owner or admin role.',
+  security: [{ Bearer: [] }],
+  request: {
+    params: z.object({ id: z.string().openapi({ param: { name: 'id', in: 'path' } }) }),
+    body: { content: { 'application/json': { schema: updateTenantSchema } } },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: tenantResponseSchema } },
+      description: 'Tenant updated',
+    },
+    403: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Insufficient permissions',
+    },
+    404: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Tenant not found',
+    },
+  },
+  tags: ['Tenants'],
+});
+
+export const deleteTenantRouteDef = createRoute({
+  method: 'delete',
+  path: '/{id}',
+  summary: 'Delete tenant',
+  description: 'Delete a tenant. Requires owner or admin role.',
+  security: [{ Bearer: [] }],
+  request: { params: z.object({ id: z.string().openapi({ param: { name: 'id', in: 'path' } }) }) },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.object({ message: z.string() }) } },
+      description: 'Tenant deleted',
+    },
+    403: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Insufficient permissions',
+    },
+    404: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Tenant not found',
+    },
+  },
+  tags: ['Tenants'],
+});
+
+// Tenant package patterns
+export const listTenantPackagesRouteDef = createRoute({
+  method: 'get',
+  path: '/{id}/packages',
+  summary: 'List tenant package patterns',
+  description: 'List all package access patterns for this tenant',
+  security: [{ Bearer: [] }],
+  request: { params: z.object({ id: z.string().openapi({ param: { name: 'id', in: 'path' } }) }) },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.array(tenantPackageResponseSchema) } },
+      description: 'List of package patterns',
+    },
+  },
+  tags: ['Tenants'],
+});
+
+export const addTenantPackageRouteDef = createRoute({
+  method: 'post',
+  path: '/{id}/packages',
+  summary: 'Add package pattern to tenant',
+  description: 'Add a package access pattern. Requires owner or admin role.',
+  security: [{ Bearer: [] }],
+  request: {
+    params: z.object({ id: z.string().openapi({ param: { name: 'id', in: 'path' } }) }),
+    body: { content: { 'application/json': { schema: addTenantPackageSchema } } },
+  },
+  responses: {
+    201: {
+      content: { 'application/json': { schema: tenantPackageResponseSchema } },
+      description: 'Package pattern added',
+    },
+    400: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Invalid request',
+    },
+    403: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Insufficient permissions',
+    },
+    409: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Pattern already exists for this tenant',
+    },
+  },
+  tags: ['Tenants'],
+});
+
+export const removeTenantPackageRouteDef = createRoute({
+  method: 'delete',
+  path: '/{id}/packages/{package_id}',
+  summary: 'Remove package pattern from tenant',
+  description: 'Remove a package access pattern. Requires owner or admin role.',
+  security: [{ Bearer: [] }],
+  request: {
+    params: z.object({
+      id: z.string().openapi({ param: { name: 'id', in: 'path' } }),
+      package_id: z.string().openapi({ param: { name: 'package_id', in: 'path' } }),
+    }),
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.object({ message: z.string() }) } },
+      description: 'Package pattern removed',
+    },
+    403: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Insufficient permissions',
+    },
+    404: {
+      content: { 'application/json': { schema: errorResponseSchema } },
+      description: 'Package pattern not found',
+    },
+  },
+  tags: ['Tenants'],
+});
+
+export {
+  createTenantSchema,
+  updateTenantSchema,
+  addTenantPackageSchema,
+};


### PR DESCRIPTION
## Summary

- Adds `organizations` module: full CRUD with ownership, member management (add/update role/remove), role hierarchy (owner > admin > member)
- Adds `tenants` module: CRUD scoped to organization, tenant package pattern management with validated vendor/package format
- Mounts both modules under `protectedRoutes` in factory.ts
- Tenants are accessed via `/api/organizations/:org_id/tenants/` with org_id injected via middleware

## Test plan

- [ ] `npm run typecheck` passes across all packages
- [ ] `npx vitest run` — all 181 tests pass
- [ ] Verify authorization: only owner can change admin roles, admins can't demote peers
- [ ] Verify tenant operations are scoped to organization (no cross-org leakage)
- [ ] Verify package pattern validation rejects invalid formats

Closes #102 (partial — CRUD API, tenant composer endpoints in next PR)