### PR TITLE
feat(core): add GitLab and Bitbucket VCS providers

### DIFF
--- a/packages/core/src/__tests__/sync.test.ts
+++ b/packages/core/src/__tests__/sync.test.ts
@@ -4,6 +4,7 @@ import { createDatabase } from '../db/create-database';
 import { decryptCredentials } from '../utils/encryption';
 import { syncGitHubRepository } from '../sync/github-sync';
 import { syncComposerRepository } from '../sync/strategies/composer-repo';
+import { registerBuiltinVcsProviders } from '../vcs';
 
 vi.mock('../db/create-database');
 vi.mock('../utils/encryption');
@@ -19,6 +20,9 @@ vi.mock('../utils/analytics', () => ({
         trackRepositorySyncFailure: vi.fn(),
     }),
 }));
+
+// Register VCS providers so the registry can resolve GitHub URLs
+registerBuiltinVcsProviders();
 
 describe('Repository Sync', () => {
     const mockEnv = {
@@ -57,7 +61,7 @@ describe('Repository Sync', () => {
                 vcs_type: 'git',
                 url: 'https://github.com/owner/repo',
                 auth_credentials: 'encrypted',
-                credential_type: 'token',
+                credential_type: 'github_token',
             }])
             .mockResolvedValue([]); // For storePackages check
 
@@ -121,6 +125,7 @@ describe('Repository Sync', () => {
             vcs_type: 'git',
             url: 'https://github.com/owner/fail',
             auth_credentials: 'encrypted',
+            credential_type: 'github_token',
         }]);
 
         (decryptCredentials as any).mockResolvedValue('{}');

--- a/packages/core/src/__tests__/vcs-providers.test.ts
+++ b/packages/core/src/__tests__/vcs-providers.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GitHubProvider } from '../vcs/github-provider';
+import { GitLabProvider } from '../vcs/gitlab-provider';
+import { BitbucketProvider } from '../vcs/bitbucket-provider';
+import {
+  VcsProviderRegistry,
+  resetVcsProviderRegistry,
+  getVcsProviderRegistry,
+} from '../vcs/registry';
+import { registerBuiltinVcsProviders } from '../vcs';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Mock pRetry to just call the function directly
+vi.mock('p-retry', () => ({
+  default: (fn: () => Promise<unknown>) => fn(),
+}));
+
+// Mock logger
+vi.mock('../utils/logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('VcsProviderRegistry', () => {
+  let registry: VcsProviderRegistry;
+
+  beforeEach(() => {
+    registry = new VcsProviderRegistry();
+  });
+
+  it('should register and resolve providers', () => {
+    const github = new GitHubProvider();
+    registry.register(github);
+
+    expect(registry.getProviderNames()).toEqual(['github']);
+    expect(registry.resolve('https://github.com/acme/repo')).toBe(github);
+  });
+
+  it('should not duplicate providers', () => {
+    registry.register(new GitHubProvider());
+    registry.register(new GitHubProvider());
+
+    expect(registry.getProviderNames()).toEqual(['github']);
+  });
+
+  it('should return null for unmatched URLs', () => {
+    registry.register(new GitHubProvider());
+
+    expect(registry.resolve('https://sourceforge.net/acme/repo')).toBeNull();
+  });
+
+  it('should resolve the correct provider by URL', () => {
+    registry.register(new GitHubProvider());
+    registry.register(new GitLabProvider());
+    registry.register(new BitbucketProvider());
+
+    const github = registry.resolve('https://github.com/acme/repo');
+    expect(github?.name).toBe('github');
+
+    const gitlab = registry.resolve('https://gitlab.com/acme/repo');
+    expect(gitlab?.name).toBe('gitlab');
+
+    const bitbucket = registry.resolve('https://bitbucket.org/acme/repo');
+    expect(bitbucket?.name).toBe('bitbucket');
+  });
+});
+
+describe('registerBuiltinVcsProviders', () => {
+  beforeEach(() => {
+    resetVcsProviderRegistry();
+  });
+
+  afterEach(() => {
+    resetVcsProviderRegistry();
+  });
+
+  it('should register all three built-in providers', () => {
+    registerBuiltinVcsProviders();
+    const registry = getVcsProviderRegistry();
+
+    expect(registry.getProviderNames()).toContain('github');
+    expect(registry.getProviderNames()).toContain('gitlab');
+    expect(registry.getProviderNames()).toContain('bitbucket');
+  });
+
+  it('should be idempotent', () => {
+    registerBuiltinVcsProviders();
+    registerBuiltinVcsProviders();
+    const registry = getVcsProviderRegistry();
+
+    expect(registry.getProviderNames()).toHaveLength(3);
+  });
+});
+
+describe('GitHubProvider', () => {
+  const provider = new GitHubProvider();
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('should match GitHub URLs', () => {
+    expect(provider.matchesUrl('https://github.com/acme/repo')).toBe(true);
+    expect(provider.matchesUrl('https://github.com/acme/repo.git')).toBe(true);
+    expect(provider.matchesUrl('git@github.com:acme/repo.git')).toBe(true);
+    expect(provider.matchesUrl('https://gitlab.com/acme/repo')).toBe(false);
+  });
+
+  it('should discover packages from GitHub Packages registry', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        packages: {
+          'acme/foo': { '1.0.0': {}, '2.0.0': {} },
+          'acme/bar': { '1.0.0': {} },
+        },
+      }),
+    );
+
+    const packages = await provider.discoverPackages('acme', 'ghp_token123');
+
+    expect(packages).toHaveLength(2);
+    expect(packages[0]).toEqual({
+      name: 'acme/foo',
+      versions: ['1.0.0', '2.0.0'],
+      source: 'github_packages',
+    });
+  });
+
+  it('should filter discovered packages', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        packages: {
+          'acme/foo': { '1.0.0': {} },
+          'acme/bar': { '1.0.0': {} },
+        },
+      }),
+    );
+
+    const packages = await provider.discoverPackages('acme', 'ghp_token123', 'foo');
+
+    expect(packages).toHaveLength(1);
+    expect(packages[0].name).toBe('acme/foo');
+  });
+
+  it('should verify credentials against GitHub API', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ login: 'testuser' }));
+
+    const valid = await provider.verifyCredentials(
+      'https://github.com/acme/repo',
+      'github_token',
+      JSON.stringify({ token: 'ghp_valid' }),
+    );
+
+    expect(valid).toBe(true);
+  });
+
+  it('should reject invalid credential types', async () => {
+    const valid = await provider.verifyCredentials(
+      'https://github.com/acme/repo',
+      'gitlab_token',
+      JSON.stringify({ token: 'glpat-xxx' }),
+    );
+
+    expect(valid).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('GitLabProvider', () => {
+  const provider = new GitLabProvider();
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('should match gitlab.com URLs only', () => {
+    expect(provider.matchesUrl('https://gitlab.com/acme/repo')).toBe(true);
+    expect(provider.matchesUrl('https://gitlab.example.com/acme/repo')).toBe(false);
+    expect(provider.matchesUrl('https://github.com/acme/repo')).toBe(false);
+  });
+
+  it('should resolve gitlab.com URLs via registry', () => {
+    const reg = new VcsProviderRegistry();
+    reg.register(provider);
+    expect(reg.resolve('https://gitlab.com/acme/repo')?.name).toBe('gitlab');
+    expect(reg.resolve('https://gitlab.com/acme/subgroup/repo')?.name).toBe('gitlab');
+  });
+
+  it('should discover packages from GitLab group registry', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse([
+        { name: 'acme/foo', version: '1.0.0' },
+        { name: 'acme/foo', version: '2.0.0' },
+        { name: 'acme/bar', version: '1.0.0' },
+      ]),
+    );
+
+    const packages = await provider.discoverPackages('acme', 'glpat-token123');
+
+    expect(packages).toHaveLength(2);
+    expect(packages[0]).toEqual({
+      name: 'acme/foo',
+      versions: ['1.0.0', '2.0.0'],
+      source: 'gitlab_packages',
+    });
+  });
+
+  it('should sync a GitLab repository', async () => {
+    // Project info
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        id: 123,
+        name: 'repo',
+        description: 'Test repo',
+        web_url: 'https://gitlab.com/acme/repo',
+        default_branch: 'main',
+      }),
+    );
+
+    // composer.json
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        name: 'acme/repo',
+        description: 'A test package',
+        type: 'library',
+      }),
+    );
+
+    // Tags
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse([
+        { name: 'v1.0.0', commit: { id: 'abc123' } },
+        { name: 'v2.0.0', commit: { id: 'def456' } },
+      ]),
+    );
+
+    const result = await provider.syncRepository(
+      'https://gitlab.com/acme/repo',
+      { token: 'glpat-xxx' },
+      'gitlab_token',
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.strategy).toBe('gitlab_api');
+    // dev-main + 2 tags
+    expect(result.packages).toHaveLength(3);
+    expect(result.packages[0].version).toBe('dev-main');
+    expect(result.packages[1].version).toBe('1.0.0');
+    expect(result.packages[2].version).toBe('2.0.0');
+  });
+
+  it('should return auth_failed on 401', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}, 401));
+
+    const result = await provider.syncRepository(
+      'https://gitlab.com/acme/repo',
+      { token: 'bad-token' },
+      'gitlab_token',
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('auth_failed');
+  });
+
+  it('should verify credentials', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ username: 'test' }));
+
+    const valid = await provider.verifyCredentials(
+      'https://gitlab.com/acme/repo',
+      'gitlab_token',
+      JSON.stringify({ token: 'glpat-valid' }),
+    );
+
+    expect(valid).toBe(true);
+  });
+});
+
+describe('BitbucketProvider', () => {
+  const provider = new BitbucketProvider();
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('should match Bitbucket URLs', () => {
+    expect(provider.matchesUrl('https://bitbucket.org/acme/repo')).toBe(true);
+    expect(provider.matchesUrl('https://github.com/acme/repo')).toBe(false);
+    expect(provider.matchesUrl('https://gitlab.com/acme/repo')).toBe(false);
+  });
+
+  it('should sync a Bitbucket repository', async () => {
+    // Repo info
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        slug: 'repo',
+        full_name: 'acme/repo',
+        description: 'Test repo',
+        mainbranch: { name: 'main' },
+        links: { html: { href: 'https://bitbucket.org/acme/repo' } },
+      }),
+    );
+
+    // composer.json
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        name: 'acme/repo',
+        description: 'A Bitbucket package',
+        type: 'library',
+      }),
+    );
+
+    // Tags
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        values: [
+          { name: 'v1.0.0', target: { hash: 'aaa111', date: '2025-01-01T00:00:00Z' } },
+          { name: 'v1.1.0', target: { hash: 'bbb222', date: '2025-06-01T00:00:00Z' } },
+        ],
+      }),
+    );
+
+    const result = await provider.syncRepository(
+      'https://bitbucket.org/acme/repo',
+      { username: 'user', password: 'app-pass' },
+      'bitbucket_app_password',
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.strategy).toBe('bitbucket_api');
+    // dev-main + 2 tags
+    expect(result.packages).toHaveLength(3);
+    expect(result.packages[0].version).toBe('dev-main');
+    expect(result.packages[1].version).toBe('1.0.0');
+    expect(result.packages[2].version).toBe('1.1.0');
+  });
+
+  it('should return auth_failed on 401', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}, 401));
+
+    const result = await provider.syncRepository(
+      'https://bitbucket.org/acme/repo',
+      { username: 'user', password: 'bad' },
+      'bitbucket_app_password',
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('auth_failed');
+  });
+
+  it('should return invalid URL error', async () => {
+    const result = await provider.syncRepository(
+      'https://example.com/acme/repo',
+      { token: 'xxx' },
+      'bitbucket_api_token',
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('invalid_bitbucket_url');
+  });
+
+  it('should verify credentials', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ username: 'test' }));
+
+    const valid = await provider.verifyCredentials(
+      'https://bitbucket.org/acme/repo',
+      'bitbucket_app_password',
+      JSON.stringify({ username: 'user', password: 'app-pass' }),
+    );
+
+    expect(valid).toBe(true);
+  });
+
+  it('should reject invalid credential types', async () => {
+    const valid = await provider.verifyCredentials(
+      'https://bitbucket.org/acme/repo',
+      'github_token',
+      JSON.stringify({ token: 'ghp_xxx' }),
+    );
+
+    expect(valid).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -23,6 +23,7 @@ import organizationsModule from './modules/organizations';
 import tenantsModule from './modules/tenants';
 import { getPackageStatsRouteDef } from './modules/admin/admin.routes';
 import { getPackageStats } from './modules/admin/admin.handlers';
+import { registerBuiltinVcsProviders } from './vcs';
 
 // Generic Environment Interface
 export interface AppBindings {
@@ -59,6 +60,9 @@ export function createApp(options?: {
 }): AppInstance {
     const app = new OpenAPIHono<{ Bindings: AppBindings; Variables: AppVariables }>();
     const logger = getLogger('info'); // Default logger, can vary per request if needed
+
+    // Register built-in VCS providers (GitHub, GitLab, Bitbucket)
+    registerBuiltinVcsProviders();
 
     // Global middleware
     app.use('*', cors());

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,4 +16,5 @@ export * from './workflows';
 export * from './services/UserService';
 export * from './services/EmailService';
 export * from './ports';
+export * from './vcs';
 export * from './factory';

--- a/packages/core/src/modules/repositories/repositories.handlers.ts
+++ b/packages/core/src/modules/repositories/repositories.handlers.ts
@@ -15,6 +15,7 @@ import { isGitHubUrl, isSshGitUrl } from '../../utils/upstream-fetch';
 import { isSshSupported } from '../../utils/environment';
 import { nanoid } from 'nanoid';
 import { getAnalytics } from '../../utils/analytics';
+import { getVcsProviderRegistry } from '../../vcs/registry';
 
 export interface RepositoriesRouteEnv {
   Bindings: {
@@ -343,9 +344,9 @@ async function validateRepositoryCredentials(
   encryptionKey: string
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    // Handle GitHub repositories differently
+    // Handle git repositories via VCS provider registry (supports GitHub, GitLab, Bitbucket)
     if (repo.vcs_type === 'git') {
-      return validateGitHubRepository(repo, encryptionKey);
+      return validateGitRepository(repo, encryptionKey);
     }
 
     // Composer repository validation (existing logic)
@@ -387,6 +388,57 @@ async function validateRepositoryCredentials(
       error: error instanceof Error ? error.message : 'Unknown error during validation',
     };
   }
+}
+
+/**
+ * Validate a git repository using VCS provider registry.
+ * Supports GitHub, GitLab, and Bitbucket URLs.
+ */
+async function validateGitRepository(
+  repo: typeof repositories.$inferSelect,
+  encryptionKey: string
+): Promise<{ success: boolean; error?: string }> {
+  // SSH key authentication is handled separately
+  if (repo.credential_type === 'ssh_key') {
+    if (!isSshSupported()) {
+      return {
+        success: false,
+        error: 'SSH key authentication is not supported in this environment. SSH keys are only available in Node.js/Docker environments.',
+      };
+    }
+    if (!repo.url || !isSshGitUrl(repo.url)) {
+      return { success: false, error: 'Invalid repository URL for SSH authentication.' };
+    }
+    return { success: true };
+  }
+
+  // Check if any VCS provider recognizes this URL
+  const registry = getVcsProviderRegistry();
+  const provider = registry.resolve(repo.url);
+
+  if (provider) {
+    // Decrypt credentials and verify with the provider
+    try {
+      const credentialsJson = await decryptCredentials(repo.auth_credentials, encryptionKey);
+      const valid = await provider.verifyCredentials(
+        repo.url,
+        repo.credential_type,
+        credentialsJson,
+      );
+      if (!valid) {
+        return { success: false, error: 'Authentication failed. Please check your credentials.' };
+      }
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error during validation',
+      };
+    }
+  }
+
+  // Fallback to GitHub-specific validation for backward compatibility
+  return validateGitHubRepository(repo, encryptionKey);
 }
 
 /**

--- a/packages/core/src/sync/repository-sync.ts
+++ b/packages/core/src/sync/repository-sync.ts
@@ -11,7 +11,6 @@ import { createDatabase } from '../db/create-database';
 import { repositories, packages as packagesTable } from '../db/schema';
 import { eq, and } from 'drizzle-orm';
 import { decryptCredentials } from '../utils/encryption';
-import { syncGitHubRepository } from './github-sync';
 import { syncComposerRepository } from './strategies/composer-repo';
 import type { SyncResult, ComposerPackage } from './types';
 import type { CredentialType } from '@package-broker/shared';
@@ -20,6 +19,7 @@ import { nanoid } from 'nanoid';
 import { getLogger } from '../utils/logger';
 import { getAnalytics } from '../utils/analytics';
 import { isSshSupported } from '../utils/environment';
+import { getVcsProviderRegistry } from '../vcs/registry';
 
 export interface SyncEnv {
   DB: D1Database;
@@ -215,27 +215,15 @@ async function syncGitRepository(
     );
   }
 
-  // Parse URL to extract owner/repo for GitHub API sync
-  const urlMatch = url.match(/github\.com[:/]([^/]+)\/([^/.]+)/);
+  // Resolve VCS provider from registry (supports GitHub, GitLab, Bitbucket)
+  const registry = getVcsProviderRegistry();
+  const provider = registry.resolve(url);
 
-  if (urlMatch) {
-    const [, owner, repo] = urlMatch;
-    
-    // For 'none' credential type, pass null token (public repo access)
-    const token = credentialType === 'none' 
-      ? null 
-      : (credentials.token || credentials.password || '');
-    
-    return syncGitHubRepository({
-      owner,
-      repo: repo.replace('.git', ''),
-      token,
-      composerJsonPath,
-    });
+  if (provider) {
+    return provider.syncRepository(url, credentials, credentialType, composerJsonPath);
   }
 
-  // GitLab/Bitbucket would be handled similarly
-  // For now, return error for unsupported Git hosts
+  // No registered provider matched the URL
   return {
     success: false,
     packages: [],

--- a/packages/core/src/vcs/bitbucket-provider.ts
+++ b/packages/core/src/vcs/bitbucket-provider.ts
@@ -1,0 +1,377 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+import type { VcsProviderPort, DiscoveredPackage, PackageMetadata } from '../ports';
+import type { SyncResult, ComposerPackage } from '../sync/types';
+import { COMPOSER_USER_AGENT } from '@package-broker/shared';
+import pRetry from 'p-retry';
+import { getLogger } from '../utils/logger';
+import semver from 'semver';
+
+const BITBUCKET_CLOUD_PATTERN = /bitbucket\.org\/([^/]+)\/([^/.]+)/;
+
+interface BitbucketTag {
+  name: string;
+  target: { hash: string; date?: string };
+}
+
+interface BitbucketPaginatedResponse<T> {
+  values: T[];
+  next?: string;
+  page?: number;
+  size?: number;
+}
+
+interface BitbucketRepository {
+  slug: string;
+  full_name: string;
+  description: string;
+  mainbranch?: { name: string };
+  links: { html: { href: string } };
+}
+
+export class BitbucketProvider implements VcsProviderPort {
+  readonly name = 'bitbucket';
+
+  async discoverPackages(org: string, token: string, filter?: string): Promise<DiscoveredPackage[]> {
+    const logger = getLogger();
+    const packages: DiscoveredPackage[] = [];
+
+    try {
+      // List repositories in the workspace
+      const repos = await this.listWorkspaceRepos(org, token);
+
+      for (const repo of repos) {
+        // Check if repo has a composer.json
+        const composerJson = await this.fetchComposerJson(org, repo.slug, token);
+        if (!composerJson?.name) continue;
+
+        if (filter && !composerJson.name.toLowerCase().includes(filter.toLowerCase())) {
+          continue;
+        }
+
+        // Get tags as versions
+        const tags = await this.fetchTags(org, repo.slug, { token });
+        const versions = tags
+          .map((tag: BitbucketTag) => semver.clean(tag.name) || tag.name)
+          .filter((v: string) => semver.valid(v));
+
+        packages.push({
+          name: composerJson.name,
+          versions,
+          source: 'bitbucket_api',
+        });
+      }
+    } catch (err) {
+      logger.error(
+        'Bitbucket package discovery error',
+        { org },
+        err instanceof Error ? err : new Error(String(err)),
+      );
+    }
+
+    return packages;
+  }
+
+  async fetchPackageMetadata(repoUrl: string, token: string): Promise<PackageMetadata | null> {
+    const match = repoUrl.match(BITBUCKET_CLOUD_PATTERN);
+    if (!match) return null;
+
+    const [, workspace, repoSlug] = match;
+    const composerJson = await this.fetchComposerJson(workspace, repoSlug, token);
+
+    if (!composerJson?.name) return null;
+
+    return {
+      name: composerJson.name,
+      description: composerJson.description,
+      versions: {},
+    };
+  }
+
+  async verifyCredentials(url: string, credentialType: string, credentials: string): Promise<boolean> {
+    const validTypes = [
+      'bitbucket_app_password',
+      'bitbucket_api_token',
+      'bitbucket_api_key',
+      'bitbucket_server_pat',
+      'none',
+    ];
+    if (!validTypes.includes(credentialType)) {
+      return false;
+    }
+
+    const parsed = this.parseCredentials(credentials);
+    const headers = this.buildHeaders(credentialType, parsed);
+
+    try {
+      const response = await fetch('https://api.bitbucket.org/2.0/user', { headers });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Sync a Bitbucket repository by fetching composer.json and discovering versions via tags.
+   */
+  async syncRepository(
+    url: string,
+    credentials: Record<string, string>,
+    credentialType: string,
+    composerJsonPath?: string,
+  ): Promise<SyncResult> {
+    const logger = getLogger();
+    const match = url.match(BITBUCKET_CLOUD_PATTERN);
+
+    if (!match) {
+      return { success: false, packages: [], error: 'invalid_bitbucket_url' };
+    }
+
+    const [, workspace, repoSlug] = match;
+    const headers = this.buildHeaders(credentialType, credentials);
+
+    try {
+      // Get repo info for default branch
+      const repoResponse = await pRetry(
+        () =>
+          fetch(`https://api.bitbucket.org/2.0/repositories/${encodeURIComponent(workspace)}/${encodeURIComponent(repoSlug)}`, {
+            headers,
+          }),
+        { retries: 2 },
+      );
+
+      if (!repoResponse.ok) {
+        if (repoResponse.status === 401 || repoResponse.status === 403) {
+          return { success: false, packages: [], error: 'auth_failed' };
+        }
+        if (repoResponse.status === 404) {
+          return { success: false, packages: [], error: 'repo_not_found' };
+        }
+        return { success: false, packages: [], error: `bitbucket_api_${repoResponse.status}` };
+      }
+
+      const repoInfo = (await repoResponse.json()) as BitbucketRepository;
+      const defaultBranch = repoInfo.mainbranch?.name || 'main';
+
+      // Fetch composer.json
+      const composerPath = composerJsonPath || 'composer.json';
+      const composerResponse = await pRetry(
+        () =>
+          fetch(
+            `https://api.bitbucket.org/2.0/repositories/${encodeURIComponent(workspace)}/${encodeURIComponent(repoSlug)}/src/${encodeURIComponent(defaultBranch)}/${encodeURIComponent(composerPath)}`,
+            { headers },
+          ),
+        { retries: 2 },
+      );
+
+      if (!composerResponse.ok) {
+        return { success: false, packages: [], error: 'no_composer_json_found' };
+      }
+
+      const composerJson = (await composerResponse.json()) as {
+        name?: string;
+        version?: string;
+        description?: string;
+        license?: string | string[];
+        type?: string;
+        homepage?: string;
+        require?: Record<string, string>;
+        'require-dev'?: Record<string, string>;
+      };
+
+      if (!composerJson.name) {
+        return { success: false, packages: [], error: 'no_valid_composer_json' };
+      }
+
+      // Fetch tags for version discovery
+      const tags = await this.fetchTags(workspace, repoSlug, credentials, credentialType);
+
+      const packages: ComposerPackage[] = [];
+
+      // Dev branch package
+      packages.push({
+        name: composerJson.name,
+        version: `dev-${defaultBranch}`,
+        description: composerJson.description,
+        license: composerJson.license,
+        type: composerJson.type,
+        homepage: composerJson.homepage || repoInfo.links.html.href,
+        require: composerJson.require,
+        'require-dev': composerJson['require-dev'],
+        dist: {
+          type: 'zip',
+          url: `https://bitbucket.org/${encodeURIComponent(workspace)}/${encodeURIComponent(repoSlug)}/get/${encodeURIComponent(defaultBranch)}.zip`,
+          reference: defaultBranch,
+        },
+      });
+
+      // Tagged version packages
+      for (const tag of tags) {
+        const version = semver.clean(tag.name) || tag.name;
+        if (!semver.valid(version)) continue;
+
+        packages.push({
+          name: composerJson.name,
+          version,
+          description: composerJson.description,
+          license: composerJson.license,
+          type: composerJson.type,
+          homepage: composerJson.homepage || repoInfo.links.html.href,
+          require: composerJson.require,
+          'require-dev': composerJson['require-dev'],
+          dist: {
+            type: 'zip',
+            url: `https://bitbucket.org/${encodeURIComponent(workspace)}/${encodeURIComponent(repoSlug)}/get/${encodeURIComponent(tag.name)}.zip`,
+            reference: tag.target.hash,
+          },
+          time: tag.target.date,
+        });
+      }
+
+      logger.info('Bitbucket sync completed', {
+        workspace,
+        repo: repoSlug,
+        packageCount: packages.length,
+        tagCount: tags.length,
+      });
+
+      return { success: true, packages, strategy: 'bitbucket_api' };
+    } catch (err) {
+      logger.error(
+        'Bitbucket sync error',
+        { workspace, repo: repoSlug },
+        err instanceof Error ? err : new Error(String(err)),
+      );
+      return { success: false, packages: [], error: 'network_error' };
+    }
+  }
+
+  matchesUrl(url: string): boolean {
+    return BITBUCKET_CLOUD_PATTERN.test(url);
+  }
+
+  private async listWorkspaceRepos(
+    workspace: string,
+    token: string,
+  ): Promise<BitbucketRepository[]> {
+    const headers = this.buildHeaders('bitbucket_app_password', { token });
+    const response = await pRetry(
+      () =>
+        fetch(
+          `https://api.bitbucket.org/2.0/repositories/${encodeURIComponent(workspace)}?pagelen=100`,
+          { headers },
+        ),
+      { retries: 2 },
+    );
+
+    if (!response.ok) return [];
+
+    const data = (await response.json()) as BitbucketPaginatedResponse<BitbucketRepository>;
+    return data.values;
+  }
+
+  private async fetchComposerJson(
+    workspace: string,
+    repoSlug: string,
+    token: string,
+    credentialType: string = 'bitbucket_app_password',
+  ): Promise<{ name?: string; description?: string } | null> {
+    const headers = this.buildHeaders(credentialType, { token });
+
+    try {
+      const response = await pRetry(
+        () =>
+          fetch(
+            `https://api.bitbucket.org/2.0/repositories/${encodeURIComponent(workspace)}/${encodeURIComponent(repoSlug)}/src/HEAD/composer.json`,
+            { headers },
+          ),
+        { retries: 2 },
+      );
+
+      if (!response.ok) return null;
+
+      return (await response.json()) as { name?: string; description?: string };
+    } catch {
+      return null;
+    }
+  }
+
+  private async fetchTags(
+    workspace: string,
+    repoSlug: string,
+    credentials: Record<string, string>,
+    credentialType: string = 'bitbucket_app_password',
+  ): Promise<BitbucketTag[]> {
+    const headers = this.buildHeaders(credentialType, credentials);
+
+    try {
+      const response = await pRetry(
+        () =>
+          fetch(
+            `https://api.bitbucket.org/2.0/repositories/${encodeURIComponent(workspace)}/${encodeURIComponent(repoSlug)}/refs/tags?pagelen=100`,
+            { headers },
+          ),
+        { retries: 2 },
+      );
+
+      if (!response.ok) return [];
+
+      const data = (await response.json()) as BitbucketPaginatedResponse<BitbucketTag>;
+      return data.values;
+    } catch {
+      return [];
+    }
+  }
+
+  private buildHeaders(
+    credentialType: string,
+    credentials: Record<string, string>,
+  ): Record<string, string> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      'User-Agent': COMPOSER_USER_AGENT,
+    };
+
+    switch (credentialType) {
+      case 'bitbucket_app_password': {
+        const username = credentials.username || '';
+        const password = credentials.password || credentials.token || '';
+        if (username && password) {
+          headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+        }
+        break;
+      }
+      case 'bitbucket_api_token':
+      case 'bitbucket_server_pat': {
+        const token = credentials.token || '';
+        if (token) {
+          headers['Authorization'] = `Bearer ${token}`;
+        }
+        break;
+      }
+      case 'bitbucket_api_key': {
+        const key = credentials.key || '';
+        if (key) {
+          headers['Authorization'] = `Basic ${btoa(`${key}:`)}`;
+        }
+        break;
+      }
+      case 'none':
+        break;
+    }
+
+    return headers;
+  }
+
+  private parseCredentials(credentials: string): Record<string, string> {
+    try {
+      return JSON.parse(credentials);
+    } catch {
+      return { token: credentials };
+    }
+  }
+}

--- a/packages/core/src/vcs/github-provider.ts
+++ b/packages/core/src/vcs/github-provider.ts
@@ -1,0 +1,160 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+import type { VcsProviderPort, DiscoveredPackage, PackageMetadata } from '../ports';
+import type { SyncResult } from '../sync/types';
+import { syncGitHubRepository } from '../sync/github-sync';
+import { COMPOSER_USER_AGENT } from '@package-broker/shared';
+import pRetry from 'p-retry';
+
+const GITHUB_URL_PATTERN = /github\.com[:/]([^/]+)\/([^/.]+)/;
+
+export class GitHubProvider implements VcsProviderPort {
+  readonly name = 'github';
+
+  async discoverPackages(org: string, token: string, filter?: string): Promise<DiscoveredPackage[]> {
+    const url = `https://composer.pkg.github.com/${encodeURIComponent(org)}/packages.json`;
+
+    const response = await pRetry(
+      () =>
+        fetch(url, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/json',
+            'User-Agent': COMPOSER_USER_AGENT,
+          },
+        }),
+      { retries: 3 },
+    );
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const data = (await response.json()) as {
+      packages?: Record<string, Record<string, unknown>>;
+    };
+
+    const packages: DiscoveredPackage[] = [];
+    for (const [name, versions] of Object.entries(data.packages || {})) {
+      if (filter && !name.toLowerCase().includes(filter.toLowerCase())) {
+        continue;
+      }
+      packages.push({ name, versions: Object.keys(versions), source: 'github_packages' });
+    }
+
+    return packages;
+  }
+
+  async fetchPackageMetadata(repoUrl: string, token: string): Promise<PackageMetadata | null> {
+    const match = repoUrl.match(GITHUB_URL_PATTERN);
+    if (!match) return null;
+
+    const [, owner, repo] = match;
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github.raw+json',
+      'User-Agent': 'PackageBroker/1.0',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    const response = await pRetry(
+      () =>
+        fetch(`https://api.github.com/repos/${owner}/${repo}/contents/composer.json`, {
+          headers,
+        }),
+      { retries: 2 },
+    );
+
+    if (!response.ok) return null;
+
+    const composerJson = (await response.json()) as {
+      name?: string;
+      description?: string;
+      version?: string;
+    };
+
+    if (!composerJson.name) return null;
+
+    return {
+      name: composerJson.name,
+      description: composerJson.description,
+      versions: {},
+    };
+  }
+
+  async verifyCredentials(url: string, credentialType: string, credentials: string): Promise<boolean> {
+    if (credentialType !== 'github_token' && credentialType !== 'none') {
+      return false;
+    }
+
+    const parsed = this.parseCredentials(credentials);
+    const token = parsed.token || '';
+
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'PackageBroker/1.0',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    try {
+      const match = url.match(GITHUB_URL_PATTERN);
+      const apiUrl = match
+        ? `https://api.github.com/repos/${match[1]}/${match[2]}`
+        : 'https://api.github.com/user';
+
+      const response = await fetch(apiUrl, { headers });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Sync a GitHub repository using the existing strategy-based sync.
+   * This bridges the VcsProviderPort interface with the current sync implementation.
+   */
+  async syncRepository(
+    url: string,
+    credentials: Record<string, string>,
+    credentialType: string,
+    composerJsonPath?: string,
+  ): Promise<SyncResult> {
+    const match = url.match(GITHUB_URL_PATTERN);
+    if (!match) {
+      return { success: false, packages: [], error: 'invalid_github_url' };
+    }
+
+    const [, owner, repo] = match;
+    const token =
+      credentialType === 'none' ? null : credentials.token || credentials.password || '';
+
+    return syncGitHubRepository({
+      owner,
+      repo: repo.replace('.git', ''),
+      token,
+      composerJsonPath,
+    });
+  }
+
+  matchesUrl(url: string): boolean {
+    return GITHUB_URL_PATTERN.test(url);
+  }
+
+  private parseCredentials(credentials: string): Record<string, string> {
+    try {
+      return JSON.parse(credentials);
+    } catch {
+      return { token: credentials };
+    }
+  }
+}

--- a/packages/core/src/vcs/gitlab-provider.ts
+++ b/packages/core/src/vcs/gitlab-provider.ts
@@ -1,0 +1,320 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+import type { VcsProviderPort, DiscoveredPackage, PackageMetadata } from '../ports';
+import type { SyncResult, ComposerPackage } from '../sync/types';
+import { COMPOSER_USER_AGENT } from '@package-broker/shared';
+import pRetry from 'p-retry';
+import { getLogger } from '../utils/logger';
+import semver from 'semver';
+
+// Only match gitlab.com — self-hosted instances are not supported to prevent SSRF.
+// Self-hosted GitLab support would require an explicit allowlist.
+const GITLAB_URL_PATTERN = /gitlab\.com[:/]([^/]+(?:\/[^/]+)*)\/([^/.]+)/;
+
+interface GitLabTag {
+  name: string;
+  commit: { id: string };
+}
+
+interface GitLabProject {
+  id: number;
+  name: string;
+  description: string | null;
+  web_url: string;
+  default_branch: string;
+}
+
+export class GitLabProvider implements VcsProviderPort {
+  readonly name = 'gitlab';
+
+  async discoverPackages(org: string, token: string, filter?: string): Promise<DiscoveredPackage[]> {
+    const logger = getLogger();
+    const packages: DiscoveredPackage[] = [];
+
+    // GitLab Groups have a Composer package registry
+    const url = `https://gitlab.com/api/v4/groups/${encodeURIComponent(org)}/packages?package_type=composer&per_page=100`;
+
+    try {
+      const response = await pRetry(
+        () =>
+          fetch(url, {
+            headers: this.buildHeaders(token),
+          }),
+        { retries: 3 },
+      );
+
+      if (!response.ok) {
+        logger.warn('GitLab package discovery failed', { org, status: response.status });
+        return [];
+      }
+
+      const data = (await response.json()) as Array<{
+        name: string;
+        version: string;
+      }>;
+
+      // Group versions by package name
+      const packageMap = new Map<string, string[]>();
+      for (const pkg of data) {
+        if (filter && !pkg.name.toLowerCase().includes(filter.toLowerCase())) {
+          continue;
+        }
+        const versions = packageMap.get(pkg.name) || [];
+        versions.push(pkg.version);
+        packageMap.set(pkg.name, versions);
+      }
+
+      for (const [name, versions] of packageMap) {
+        packages.push({ name, versions, source: 'gitlab_packages' });
+      }
+    } catch (err) {
+      logger.error(
+        'GitLab package discovery error',
+        { org },
+        err instanceof Error ? err : new Error(String(err)),
+      );
+    }
+
+    return packages;
+  }
+
+  async fetchPackageMetadata(repoUrl: string, token: string): Promise<PackageMetadata | null> {
+    const { host, projectPath } = this.parseUrl(repoUrl);
+    if (!projectPath) return null;
+
+    const apiBase = `https://${host}/api/v4`;
+    const encodedPath = encodeURIComponent(projectPath);
+
+    const headers = this.buildHeaders(token);
+
+    try {
+      // Fetch project to get default branch (don't assume 'main')
+      const projectResponse = await pRetry(
+        () => fetch(`${apiBase}/projects/${encodedPath}`, { headers }),
+        { retries: 2 },
+      );
+      const defaultBranch = projectResponse.ok
+        ? ((await projectResponse.json()) as GitLabProject).default_branch || 'main'
+        : 'main';
+
+      const response = await pRetry(
+        () =>
+          fetch(`${apiBase}/projects/${encodedPath}/repository/files/composer.json/raw?ref=${encodeURIComponent(defaultBranch)}`, {
+            headers,
+          }),
+        { retries: 2 },
+      );
+
+      if (!response.ok) return null;
+
+      const composerJson = (await response.json()) as {
+        name?: string;
+        description?: string;
+      };
+
+      if (!composerJson.name) return null;
+
+      return {
+        name: composerJson.name,
+        description: composerJson.description,
+        versions: {},
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async verifyCredentials(url: string, credentialType: string, credentials: string): Promise<boolean> {
+    if (credentialType !== 'gitlab_token' && credentialType !== 'none') {
+      return false;
+    }
+
+    const parsed = this.parseCredentials(credentials);
+    const token = parsed.token || '';
+    const { host } = this.parseUrl(url);
+
+    try {
+      const response = await fetch(`https://${host}/api/v4/user`, {
+        headers: this.buildHeaders(token),
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Sync a GitLab repository by fetching composer.json from the repo and tags for versions.
+   */
+  async syncRepository(
+    url: string,
+    credentials: Record<string, string>,
+    credentialType: string,
+    composerJsonPath?: string,
+  ): Promise<SyncResult> {
+    const logger = getLogger();
+    const { host, projectPath } = this.parseUrl(url);
+
+    if (!projectPath) {
+      return { success: false, packages: [], error: 'invalid_gitlab_url' };
+    }
+
+    const token = credentialType === 'none' ? '' : credentials.token || '';
+    const apiBase = `https://${host}/api/v4`;
+    const encodedPath = encodeURIComponent(projectPath);
+    const headers = this.buildHeaders(token);
+
+    try {
+      // Get project info for default branch
+      const projectResponse = await pRetry(
+        () => fetch(`${apiBase}/projects/${encodedPath}`, { headers }),
+        { retries: 2 },
+      );
+
+      if (!projectResponse.ok) {
+        if (projectResponse.status === 401 || projectResponse.status === 403) {
+          return { success: false, packages: [], error: 'auth_failed' };
+        }
+        if (projectResponse.status === 404) {
+          return { success: false, packages: [], error: 'repo_not_found' };
+        }
+        return { success: false, packages: [], error: `gitlab_api_${projectResponse.status}` };
+      }
+
+      const project = (await projectResponse.json()) as GitLabProject;
+      const defaultBranch = project.default_branch || 'main';
+
+      // Fetch composer.json from default branch
+      const composerPath = composerJsonPath || 'composer.json';
+      const composerResponse = await pRetry(
+        () =>
+          fetch(
+            `${apiBase}/projects/${encodedPath}/repository/files/${encodeURIComponent(composerPath)}/raw?ref=${encodeURIComponent(defaultBranch)}`,
+            { headers },
+          ),
+        { retries: 2 },
+      );
+
+      if (!composerResponse.ok) {
+        return { success: false, packages: [], error: 'no_composer_json_found' };
+      }
+
+      const composerJson = (await composerResponse.json()) as {
+        name?: string;
+        version?: string;
+        description?: string;
+        license?: string | string[];
+        type?: string;
+        homepage?: string;
+        require?: Record<string, string>;
+        'require-dev'?: Record<string, string>;
+      };
+
+      if (!composerJson.name) {
+        return { success: false, packages: [], error: 'no_valid_composer_json' };
+      }
+
+      // Fetch tags for version discovery
+      const tagsResponse = await pRetry(
+        () =>
+          fetch(`${apiBase}/projects/${encodedPath}/repository/tags?per_page=100`, { headers }),
+        { retries: 2 },
+      );
+
+      const tags: GitLabTag[] = tagsResponse.ok ? ((await tagsResponse.json()) as GitLabTag[]) : [];
+
+      // Build packages from tags
+      const packages: ComposerPackage[] = [];
+
+      // Dev branch package
+      packages.push({
+        name: composerJson.name,
+        version: `dev-${defaultBranch}`,
+        description: composerJson.description,
+        license: composerJson.license,
+        type: composerJson.type,
+        homepage: composerJson.homepage || project.web_url,
+        require: composerJson.require,
+        'require-dev': composerJson['require-dev'],
+        dist: {
+          type: 'zip',
+          url: `${apiBase}/projects/${encodedPath}/repository/archive.zip?sha=${encodeURIComponent(defaultBranch)}`,
+          reference: defaultBranch,
+        },
+      });
+
+      // Tagged version packages
+      for (const tag of tags) {
+        const version = semver.clean(tag.name) || tag.name;
+        if (!semver.valid(version)) continue;
+
+        packages.push({
+          name: composerJson.name,
+          version,
+          description: composerJson.description,
+          license: composerJson.license,
+          type: composerJson.type,
+          homepage: composerJson.homepage || project.web_url,
+          require: composerJson.require,
+          'require-dev': composerJson['require-dev'],
+          dist: {
+            type: 'zip',
+            url: `${apiBase}/projects/${encodedPath}/repository/archive.zip?sha=${encodeURIComponent(tag.name)}`,
+            reference: tag.commit.id,
+          },
+        });
+      }
+
+      logger.info('GitLab sync completed', {
+        project: projectPath,
+        packageCount: packages.length,
+        tagCount: tags.length,
+      });
+
+      return { success: true, packages, strategy: 'gitlab_api' };
+    } catch (err) {
+      logger.error(
+        'GitLab sync error',
+        { project: projectPath },
+        err instanceof Error ? err : new Error(String(err)),
+      );
+      return { success: false, packages: [], error: 'network_error' };
+    }
+  }
+
+  matchesUrl(url: string): boolean {
+    return GITLAB_URL_PATTERN.test(url);
+  }
+
+  private parseUrl(url: string): { host: string; projectPath: string | null } {
+    const gitlabMatch = url.match(GITLAB_URL_PATTERN);
+    if (gitlabMatch) {
+      return { host: 'gitlab.com', projectPath: `${gitlabMatch[1]}/${gitlabMatch[2]}` };
+    }
+
+    return { host: 'gitlab.com', projectPath: null };
+  }
+
+  private buildHeaders(token: string): Record<string, string> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      'User-Agent': COMPOSER_USER_AGENT,
+    };
+    if (token) {
+      headers['PRIVATE-TOKEN'] = token;
+    }
+    return headers;
+  }
+
+  private parseCredentials(credentials: string): Record<string, string> {
+    try {
+      return JSON.parse(credentials);
+    } catch {
+      return { token: credentials };
+    }
+  }
+}

--- a/packages/core/src/vcs/index.ts
+++ b/packages/core/src/vcs/index.ts
@@ -1,0 +1,31 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+export { GitHubProvider } from './github-provider';
+export { GitLabProvider } from './gitlab-provider';
+export { BitbucketProvider } from './bitbucket-provider';
+export {
+  VcsProviderRegistry,
+  getVcsProviderRegistry,
+  resetVcsProviderRegistry,
+  type SyncableVcsProvider,
+} from './registry';
+
+import { getVcsProviderRegistry } from './registry';
+import { GitHubProvider } from './github-provider';
+import { GitLabProvider } from './gitlab-provider';
+import { BitbucketProvider } from './bitbucket-provider';
+
+/**
+ * Initialize the VCS provider registry with all built-in providers.
+ * Call this once during application startup.
+ */
+export function registerBuiltinVcsProviders(): void {
+  const registry = getVcsProviderRegistry();
+  registry.register(new GitHubProvider());
+  registry.register(new GitLabProvider());
+  registry.register(new BitbucketProvider());
+}

--- a/packages/core/src/vcs/registry.ts
+++ b/packages/core/src/vcs/registry.ts
@@ -1,0 +1,71 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+import type { SyncResult } from '../sync/types';
+
+/**
+ * Extended VCS provider interface that adds sync and URL-matching capabilities
+ * beyond the base VcsProviderPort.
+ */
+export interface SyncableVcsProvider {
+  readonly name: string;
+  matchesUrl(url: string): boolean;
+  verifyCredentials(url: string, credentialType: string, credentials: string): Promise<boolean>;
+  syncRepository(
+    url: string,
+    credentials: Record<string, string>,
+    credentialType: string,
+    composerJsonPath?: string,
+  ): Promise<SyncResult>;
+}
+
+/**
+ * Registry for VCS providers. Resolves the correct provider based on repository URL.
+ */
+export class VcsProviderRegistry {
+  private readonly providers: SyncableVcsProvider[] = [];
+
+  register(provider: SyncableVcsProvider): void {
+    // Avoid duplicate registration
+    if (this.providers.some((p) => p.name === provider.name)) {
+      return;
+    }
+    this.providers.push(provider);
+  }
+
+  /**
+   * Find a provider that can handle the given URL.
+   */
+  resolve(url: string): SyncableVcsProvider | null {
+    return this.providers.find((p) => p.matchesUrl(url)) || null;
+  }
+
+  /**
+   * Get all registered provider names.
+   */
+  getProviderNames(): string[] {
+    return this.providers.map((p) => p.name);
+  }
+}
+
+/**
+ * Singleton registry instance used across the application.
+ */
+let registryInstance: VcsProviderRegistry | null = null;
+
+export function getVcsProviderRegistry(): VcsProviderRegistry {
+  if (!registryInstance) {
+    registryInstance = new VcsProviderRegistry();
+  }
+  return registryInstance;
+}
+
+/**
+ * Reset the registry (for testing).
+ */
+export function resetVcsProviderRegistry(): void {
+  registryInstance = null;
+}


### PR DESCRIPTION
## Summary

- Implements VCS provider registry pattern to support multiple Git hosting platforms
- Adds `GitHubProvider`, `GitLabProvider`, and `BitbucketProvider` implementing `VcsProviderPort`
- Registry resolves providers by URL pattern, delegates sync/validation to appropriate provider
- Updates `repository-sync.ts` to use registry instead of hardcoded GitHub URL matching
- Updates repository validation to support GitLab/Bitbucket credential types
- 23 new tests covering all providers and registry

## Security considerations

- GitLab restricted to `gitlab.com` only (no self-hosted) to prevent SSRF
- `parseUrl` is private to limit surface for future misuse
- Full credentials passed through tag fetch paths (Bitbucket auth fix)
- Credential verification delegated to provider-specific implementations

## Test plan

- [x] All 204 tests pass (`npx vitest run`)
- [x] TypeScript strict mode passes (`npm run typecheck`)
- [x] ESLint passes with 0 errors (`npm run lint -w packages/core`)
- [x] Codex GPT-5 code review — 4 findings fixed
- [x] Claude code review — remaining findings fixed
- [ ] CI passes (lint, typecheck, test, E2E, Docker smoke)

Refs #100