### PR TITLE
feat(cli): add migration CLI for Satis and Private Packagist

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,8 @@
   "description": "CLI tool to initialize PACKAGE.broker configuration",
   "type": "module",
   "bin": {
-    "package-broker": "./dist/index.js"
+    "package-broker": "./dist/index.js",
+    "package-broker-migrate": "./dist/migrate.js"
   },
   "files": [
     "dist",

--- a/packages/cli/src/__tests__/migrate.test.ts
+++ b/packages/cli/src/__tests__/migrate.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  rewriteComposerJson,
+  estimateSavings,
+  discoverFromSatis,
+  discoverFromPrivatePackagist,
+  type ComposerJson,
+} from '../migrate';
+
+// Prevent main() from running on import
+vi.mock('fs', () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(() => false),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Mock process.argv and process.exit
+vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+
+describe('rewriteComposerJson', () => {
+  it('should replace matching repository URL', () => {
+    const input: ComposerJson = {
+      name: 'acme/app',
+      repositories: [
+        { type: 'composer', url: 'https://satis.example.com' },
+        { type: 'vcs', url: 'https://github.com/acme/lib' },
+      ],
+    };
+
+    const result = rewriteComposerJson(
+      input,
+      'https://satis.example.com',
+      'https://broker.example.com',
+    );
+
+    expect(result.repositories).toEqual([
+      { type: 'composer', url: 'https://broker.example.com' },
+      { type: 'vcs', url: 'https://github.com/acme/lib' },
+    ]);
+  });
+
+  it('should handle trailing slashes', () => {
+    const input: ComposerJson = {
+      repositories: [
+        { type: 'composer', url: 'https://satis.example.com/' },
+      ],
+    };
+
+    const result = rewriteComposerJson(
+      input,
+      'https://satis.example.com',
+      'https://broker.example.com/',
+    );
+
+    expect(result.repositories![0].url).toBe('https://broker.example.com');
+  });
+
+  it('should be case insensitive for URL matching', () => {
+    const input: ComposerJson = {
+      repositories: [
+        { type: 'composer', url: 'https://Satis.Example.COM' },
+      ],
+    };
+
+    const result = rewriteComposerJson(
+      input,
+      'https://satis.example.com',
+      'https://broker.example.com',
+    );
+
+    expect(result.repositories![0].url).toBe('https://broker.example.com');
+  });
+
+  it('should not modify non-matching repositories', () => {
+    const input: ComposerJson = {
+      repositories: [
+        { type: 'composer', url: 'https://other-registry.com' },
+      ],
+    };
+
+    const result = rewriteComposerJson(
+      input,
+      'https://satis.example.com',
+      'https://broker.example.com',
+    );
+
+    expect(result.repositories![0].url).toBe('https://other-registry.com');
+  });
+
+  it('should handle missing repositories array', () => {
+    const input: ComposerJson = { name: 'acme/app' };
+
+    const result = rewriteComposerJson(
+      input,
+      'https://satis.example.com',
+      'https://broker.example.com',
+    );
+
+    expect(result.repositories).toBeUndefined();
+  });
+});
+
+describe('estimateSavings', () => {
+  it('should estimate Private Packagist costs by tier', () => {
+    expect(estimateSavings('packagist', 3).monthly_cost).toBe(0);
+    expect(estimateSavings('packagist', 8).monthly_cost).toBe(7);
+    expect(estimateSavings('packagist', 30).monthly_cost).toBe(35);
+    expect(estimateSavings('packagist', 100).monthly_cost).toBe(119);
+    expect(estimateSavings('packagist', 200).monthly_cost).toBe(299);
+  });
+
+  it('should estimate Satis hosting costs', () => {
+    const small = estimateSavings('satis', 20);
+    expect(small.monthly_cost).toBe(10);
+
+    const large = estimateSavings('satis', 100);
+    expect(large.monthly_cost).toBe(20);
+  });
+
+  it('should calculate annual savings', () => {
+    const result = estimateSavings('packagist', 100);
+    expect(result.annual_cost).toBe(result.monthly_cost * 12);
+    expect(result.annual_savings).toBe(result.annual_cost);
+  });
+});
+
+describe('discoverFromSatis', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('should discover packages from Satis packages.json', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          packages: {
+            'acme/foo': { '1.0.0': {}, '2.0.0': {} },
+            'acme/bar': { '1.0.0': {} },
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const packages = await discoverFromSatis('https://satis.example.com');
+
+    expect(packages).toHaveLength(2);
+    expect(packages[0]).toEqual({ name: 'acme/foo', versions: ['1.0.0', '2.0.0'] });
+    expect(packages[1]).toEqual({ name: 'acme/bar', versions: ['1.0.0'] });
+  });
+
+  it('should throw on HTTP error', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response('Not Found', { status: 404 }),
+    );
+
+    await expect(discoverFromSatis('https://satis.example.com')).rejects.toThrow('HTTP 404');
+  });
+});
+
+describe('discoverFromPrivatePackagist', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('should discover packages with authentication', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          packages: {
+            'acme/premium': { '3.0.0': {} },
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const packages = await discoverFromPrivatePackagist(
+      'https://repo.packagist.com/acme',
+      'pp_token123',
+    );
+
+    expect(packages).toHaveLength(1);
+    expect(packages[0].name).toBe('acme/premium');
+
+    // Verify auth header was sent
+    const callHeaders = mockFetch.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(callHeaders?.Authorization).toBe('Bearer pp_token123');
+  });
+
+  it('should throw on auth failure', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response('Unauthorized', { status: 401 }),
+    );
+
+    await expect(
+      discoverFromPrivatePackagist('https://repo.packagist.com/acme', 'bad-token'),
+    ).rejects.toThrow('Authentication failed');
+  });
+});

--- a/packages/cli/src/__tests__/migrate.test.ts
+++ b/packages/cli/src/__tests__/migrate.test.ts
@@ -7,18 +7,8 @@ import {
   type ComposerJson,
 } from '../migrate';
 
-// Prevent main() from running on import
-vi.mock('fs', () => ({
-  readFileSync: vi.fn(),
-  writeFileSync: vi.fn(),
-  existsSync: vi.fn(() => false),
-}));
-
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
-
-// Mock process.argv and process.exit
-vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
 
 describe('rewriteComposerJson', () => {
   it('should replace matching repository URL', () => {

--- a/packages/cli/src/migrate.ts
+++ b/packages/cli/src/migrate.ts
@@ -1,0 +1,452 @@
+#!/usr/bin/env node
+
+/*
+ * PACKAGE.broker - Migration CLI
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+// ─── CLI colors ──────────────────────────────────────────────────
+
+const C = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  blue: '\x1b[34m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+};
+
+function log(msg: string, color = ''): void {
+  console.log(`${color}${msg}${C.reset}`);
+}
+
+function error(msg: string): void {
+  log(`Error: ${msg}`, C.red);
+}
+
+// ─── Types ───────────────────────────────────────────────────────
+
+interface ComposerJson {
+  name?: string;
+  repositories?: ComposerRepository[];
+  require?: Record<string, string>;
+  'require-dev'?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+interface ComposerRepository {
+  type: string;
+  url: string;
+  options?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+interface ComposerPackagesJson {
+  packages: Record<string, Record<string, unknown>>;
+  'provider-includes'?: Record<string, { sha256: string }>;
+  'providers-url'?: string;
+  includes?: Record<string, { sha1: string }>;
+}
+
+interface MigrateOptions {
+  from: 'satis' | 'packagist';
+  instance: string;
+  target: string;
+  token?: string;
+  dryRun: boolean;
+  composerJsonPath: string;
+}
+
+interface DiscoveredPackage {
+  name: string;
+  versions: string[];
+}
+
+// ─── Source discovery ────────────────────────────────────────────
+
+async function discoverFromSatis(url: string): Promise<DiscoveredPackage[]> {
+  const packagesUrl = `${url.replace(/\/$/, '')}/packages.json`;
+
+  const response = await fetch(packagesUrl, {
+    headers: { Accept: 'application/json', 'User-Agent': 'PackageBroker-Migrate/1.0' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${packagesUrl}: HTTP ${response.status}`);
+  }
+
+  const data = (await response.json()) as ComposerPackagesJson;
+  const packages: DiscoveredPackage[] = [];
+
+  // Handle direct packages format
+  for (const [name, versions] of Object.entries(data.packages || {})) {
+    packages.push({ name, versions: Object.keys(versions) });
+  }
+
+  // Handle provider-includes format (large Satis instances)
+  if (data.includes) {
+    for (const [includeUrl] of Object.entries(data.includes)) {
+      const resolvedUrl = `${url.replace(/\/$/, '')}/${includeUrl}`;
+      try {
+        const includeResponse = await fetch(resolvedUrl, {
+          headers: { Accept: 'application/json', 'User-Agent': 'PackageBroker-Migrate/1.0' },
+        });
+        if (includeResponse.ok) {
+          const includeData = (await includeResponse.json()) as ComposerPackagesJson;
+          for (const [name, versions] of Object.entries(includeData.packages || {})) {
+            packages.push({ name, versions: Object.keys(versions) });
+          }
+        }
+      } catch {
+        // Skip failed include files
+      }
+    }
+  }
+
+  return packages;
+}
+
+async function discoverFromPrivatePackagist(
+  url: string,
+  token?: string,
+): Promise<DiscoveredPackage[]> {
+  const packagesUrl = `${url.replace(/\/$/, '')}/packages.json`;
+
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'User-Agent': 'PackageBroker-Migrate/1.0',
+  };
+
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const response = await fetch(packagesUrl, { headers });
+
+  if (response.status === 401 || response.status === 403) {
+    throw new Error(
+      'Authentication failed. Use --token to provide your Private Packagist token.',
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${packagesUrl}: HTTP ${response.status}`);
+  }
+
+  const data = (await response.json()) as ComposerPackagesJson;
+  const packages: DiscoveredPackage[] = [];
+
+  for (const [name, versions] of Object.entries(data.packages || {})) {
+    packages.push({ name, versions: Object.keys(versions) });
+  }
+
+  return packages;
+}
+
+// ─── composer.json rewriter ──────────────────────────────────────
+
+function rewriteComposerJson(
+  composerJson: ComposerJson,
+  sourceUrl: string,
+  targetUrl: string,
+): ComposerJson {
+  const updated = { ...composerJson };
+
+  if (!updated.repositories) return updated;
+
+  const normalizedSource = sourceUrl.replace(/\/$/, '').toLowerCase();
+
+  updated.repositories = updated.repositories.map((repo) => {
+    const normalizedRepoUrl = (repo.url || '').replace(/\/$/, '').toLowerCase();
+
+    if (normalizedRepoUrl === normalizedSource) {
+      return {
+        type: 'composer',
+        url: targetUrl.replace(/\/$/, ''),
+      };
+    }
+
+    return repo;
+  });
+
+  return updated;
+}
+
+// ─── Savings calculator ──────────────────────────────────────────
+
+interface SavingsEstimate {
+  source: string;
+  monthly_cost: number;
+  annual_cost: number;
+  annual_savings: number;
+  package_count: number;
+}
+
+function estimateSavings(
+  source: 'satis' | 'packagist',
+  packageCount: number,
+): SavingsEstimate {
+  // Private Packagist pricing (as of 2025):
+  // - Free: 5 packages, 1 user
+  // - Personal: $7/mo — 10 packages
+  // - Small: $35/mo — 50 packages
+  // - Medium: $119/mo — 150 packages
+  // - Large: $299/mo — unlimited
+  // - Organization: $399/mo+ — team features
+
+  let monthlyEstimate = 0;
+
+  if (source === 'packagist') {
+    if (packageCount <= 5) monthlyEstimate = 0;
+    else if (packageCount <= 10) monthlyEstimate = 7;
+    else if (packageCount <= 50) monthlyEstimate = 35;
+    else if (packageCount <= 150) monthlyEstimate = 119;
+    else monthlyEstimate = 299;
+  } else {
+    // Satis is free but requires hosting
+    // Estimate server costs
+    monthlyEstimate = packageCount > 50 ? 20 : 10;
+  }
+
+  return {
+    source: source === 'packagist' ? 'Private Packagist' : 'Satis (hosting costs)',
+    monthly_cost: monthlyEstimate,
+    annual_cost: monthlyEstimate * 12,
+    annual_savings: monthlyEstimate * 12,
+    package_count: packageCount,
+  };
+}
+
+// ─── CLI argument parsing ────────────────────────────────────────
+
+function parseArgs(args: string[]): MigrateOptions {
+  let from: 'satis' | 'packagist' = 'satis';
+  let instance = '';
+  let target = '';
+  let token: string | undefined;
+  let dryRun = false;
+  let composerJsonPath = join(process.cwd(), 'composer.json');
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--from':
+        from = args[++i] as 'satis' | 'packagist';
+        if (from !== 'satis' && from !== 'packagist') {
+          error(`Invalid source: ${from}. Use "satis" or "packagist".`);
+          process.exit(1);
+        }
+        break;
+      case '--instance':
+        instance = args[++i];
+        break;
+      case '--target':
+        target = args[++i];
+        break;
+      case '--token':
+        token = args[++i];
+        break;
+      case '--dry-run':
+        dryRun = true;
+        break;
+      case '--composer-json':
+        composerJsonPath = args[++i];
+        break;
+      case '--help':
+      case '-h':
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        if (args[i].startsWith('--')) {
+          error(`Unknown option: ${args[i]}`);
+          printHelp();
+          process.exit(1);
+        }
+    }
+  }
+
+  if (!instance) {
+    error('Missing required --instance flag.');
+    printHelp();
+    process.exit(1);
+  }
+
+  if (!target) {
+    error('Missing required --target flag.');
+    printHelp();
+    process.exit(1);
+  }
+
+  return { from, instance, target, token, dryRun, composerJsonPath };
+}
+
+function printHelp(): void {
+  log('');
+  log('PACKAGE.broker Migration CLI', C.bold);
+  log('');
+  log('Migrate from Satis or Private Packagist to PACKAGE.broker', C.dim);
+  log('');
+  log('Usage:', C.bold);
+  log('  npx @package-broker/cli migrate --from <source> --instance <url> --target <url>');
+  log('');
+  log('Options:', C.bold);
+  log('  --from <source>         Source type: "satis" or "packagist" (default: satis)');
+  log('  --instance <url>        URL of the source registry to migrate from');
+  log('  --target <url>          URL of your PACKAGE.broker instance');
+  log('  --token <token>         Authentication token (required for Private Packagist)');
+  log('  --dry-run               Show what would be done without making changes');
+  log('  --composer-json <path>  Path to composer.json (default: ./composer.json)');
+  log('  --help, -h              Show this help message');
+  log('');
+  log('Examples:', C.bold);
+  log('  npx @package-broker/cli migrate \\');
+  log('    --from satis \\');
+  log('    --instance https://packages.example.com \\');
+  log('    --target https://broker.example.com');
+  log('');
+  log('  npx @package-broker/cli migrate \\');
+  log('    --from packagist \\');
+  log('    --instance https://repo.packagist.com/acme \\');
+  log('    --target https://broker.example.com \\');
+  log('    --token pp_xxxxxxxxxxxx \\');
+  log('    --dry-run');
+  log('');
+}
+
+// ─── Main ────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  // Remove the "migrate" subcommand if present
+  const filteredArgs = args[0] === 'migrate' ? args.slice(1) : args;
+
+  if (filteredArgs.length === 0 || filteredArgs.includes('--help') || filteredArgs.includes('-h')) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const options = parseArgs(filteredArgs);
+
+  log('');
+  log('  PACKAGE.broker Migration', C.bold);
+  log(`  ${C.dim}Migrating from ${options.from} to PACKAGE.broker${C.reset}`);
+  log('');
+
+  // Step 1: Read composer.json
+  if (!existsSync(options.composerJsonPath)) {
+    error(`composer.json not found at: ${options.composerJsonPath}`);
+    process.exit(1);
+  }
+
+  const composerJsonRaw = readFileSync(options.composerJsonPath, 'utf-8');
+  let composerJson: ComposerJson;
+  try {
+    composerJson = JSON.parse(composerJsonRaw) as ComposerJson;
+  } catch {
+    error('Invalid JSON in composer.json');
+    process.exit(1);
+  }
+
+  log(`  ${C.green}✓${C.reset} Read composer.json (${composerJson.name || 'unnamed project'})`);
+
+  // Step 2: Discover packages from source
+  log(`  ${C.cyan}→${C.reset} Discovering packages from ${options.instance}...`);
+
+  let packages: DiscoveredPackage[];
+  try {
+    if (options.from === 'packagist') {
+      packages = await discoverFromPrivatePackagist(options.instance, options.token);
+    } else {
+      packages = await discoverFromSatis(options.instance);
+    }
+  } catch (err) {
+    error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  if (packages.length === 0) {
+    log(`  ${C.yellow}⚠${C.reset} No packages found at ${options.instance}`);
+    process.exit(0);
+  }
+
+  const totalVersions = packages.reduce((sum, p) => sum + p.versions.length, 0);
+  log(
+    `  ${C.green}✓${C.reset} Found ${C.bold}${packages.length}${C.reset} packages (${totalVersions} versions)`,
+  );
+
+  // Step 3: Show what will be migrated
+  log('');
+  log('  Packages to migrate:', C.bold);
+  for (const pkg of packages.slice(0, 20)) {
+    log(`    ${C.dim}•${C.reset} ${pkg.name} (${pkg.versions.length} versions)`);
+  }
+  if (packages.length > 20) {
+    log(`    ${C.dim}... and ${packages.length - 20} more${C.reset}`);
+  }
+  log('');
+
+  // Step 4: Rewrite composer.json
+  const updatedComposerJson = rewriteComposerJson(composerJson, options.instance, options.target);
+
+  if (options.dryRun) {
+    log('  [DRY RUN] Would rewrite composer.json repositories:', C.yellow);
+    const repos = updatedComposerJson.repositories || [];
+    for (const repo of repos) {
+      log(`    ${C.dim}•${C.reset} ${repo.type}: ${repo.url}`);
+    }
+    log('');
+  } else {
+    // Write updated composer.json with proper formatting
+    const updatedJson = JSON.stringify(updatedComposerJson, null, 4) + '\n';
+    writeFileSync(options.composerJsonPath, updatedJson, 'utf-8');
+    log(`  ${C.green}✓${C.reset} Updated composer.json — repository URL changed to ${options.target}`);
+  }
+
+  // Step 5: Savings estimate
+  const savings = estimateSavings(options.from, packages.length);
+  log('');
+  log('  ─────────────────────────────────────', C.dim);
+  log('');
+  log(`  ${C.bold}💰 Estimated savings${C.reset}`);
+  log(`     Source: ${savings.source}`);
+  log(
+    `     Previous cost: ${C.yellow}$${savings.monthly_cost}/month${C.reset} ($${savings.annual_cost}/year)`,
+  );
+  log(`     PACKAGE.broker: ${C.green}$0/month${C.reset} (self-hosted)`);
+  log(`     ${C.bold}${C.green}You save $${savings.annual_savings}/year${C.reset}`);
+  log('');
+
+  if (options.dryRun) {
+    log(`  ${C.yellow}[DRY RUN]${C.reset} No changes were made. Remove --dry-run to apply.`);
+  } else {
+    log(`  ${C.bold}Next steps:${C.reset}`);
+    log(`    1. Run ${C.cyan}composer update${C.reset} to verify the migration`);
+    log(`    2. Commit the updated composer.json and composer.lock`);
+  }
+
+  log('');
+}
+
+export {
+  discoverFromSatis,
+  discoverFromPrivatePackagist,
+  rewriteComposerJson,
+  estimateSavings,
+  parseArgs,
+  type MigrateOptions,
+  type DiscoveredPackage,
+  type SavingsEstimate,
+  type ComposerJson,
+};
+
+main().catch((err) => {
+  error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/packages/cli/src/migrate.ts
+++ b/packages/cli/src/migrate.ts
@@ -446,7 +446,15 @@ export {
   type ComposerJson,
 };
 
-main().catch((err) => {
-  error(err instanceof Error ? err.message : String(err));
-  process.exit(1);
-});
+// Only run main() when executed directly (not when imported by tests)
+const isDirectExecution =
+  typeof process !== 'undefined' &&
+  process.argv[1] &&
+  (process.argv[1].endsWith('migrate.js') || process.argv[1].endsWith('migrate.ts'));
+
+if (isDirectExecution) {
+  main().catch((err) => {
+    error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `npx @package-broker/cli migrate` command for migrating from Satis or Private Packagist
- Discovers all packages from source registry (direct packages.json + includes format)
- Rewrites composer.json repositories to point to PACKAGE.broker instance
- Dry-run mode shows what would change without modifying files
- Savings calculator estimates annual cost savings by Private Packagist pricing tier
- 12 new tests covering: composer.json rewriting, savings estimation, Satis/Packagist discovery

## Usage

```bash
npx @package-broker/cli migrate \
  --from satis \
  --instance https://packages.example.com \
  --target https://broker.example.com

npx @package-broker/cli migrate \
  --from packagist \
  --instance https://repo.packagist.com/acme \
  --target https://broker.example.com \
  --token pp_xxxxxxxxxxxx \
  --dry-run
```

## Test plan

- [x] 12 new tests pass
- [x] All 235 tests pass (`npx vitest run`)
- [x] TypeScript strict mode passes (`npm run typecheck`)
- [ ] CI green