### PR TITLE
fix(release): update workspace cross-references during version bump

### DIFF
--- a/scripts/update-versions.js
+++ b/scripts/update-versions.js
@@ -11,46 +11,96 @@ const { execSync } = require('child_process');
 const rootDir = path.join(__dirname, '..');
 const packagesDir = path.join(rootDir, 'packages');
 
-function updatePackageVersion(packagePath, newVersion) {
+/**
+ * Get all workspace package names from packages/ directory.
+ */
+function getWorkspacePackageNames() {
+  const names = new Set();
+  const packages = fs.readdirSync(packagesDir, { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => path.join(packagesDir, dirent.name, 'package.json'));
+
+  for (const pkgPath of packages) {
+    if (fs.existsSync(pkgPath)) {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+      if (pkg.name) names.add(pkg.name);
+    }
+  }
+
+  // Include root package
+  const rootPkg = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
+  if (rootPkg.name) names.add(rootPkg.name);
+
+  return names;
+}
+
+/**
+ * Update a dependency map, replacing workspace package references with the new version.
+ */
+function updateWorkspaceDeps(deps, workspaceNames, newVersion) {
+  if (!deps) return false;
+  let changed = false;
+  for (const [name, range] of Object.entries(deps)) {
+    if (workspaceNames.has(name)) {
+      const newRange = `^${newVersion}`;
+      if (deps[name] !== newRange) {
+        deps[name] = newRange;
+        changed = true;
+      }
+    }
+  }
+  return changed;
+}
+
+function updatePackageVersion(packagePath, newVersion, workspaceNames) {
   const packageJsonPath = path.join(packagePath, 'package.json');
-  
+
   if (!fs.existsSync(packageJsonPath)) {
     return false;
   }
-  
+
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
   const oldVersion = packageJson.version;
   packageJson.version = newVersion;
-  
+
+  // Also update workspace cross-references in dependencies
+  updateWorkspaceDeps(packageJson.dependencies, workspaceNames, newVersion);
+  updateWorkspaceDeps(packageJson.devDependencies, workspaceNames, newVersion);
+  updateWorkspaceDeps(packageJson.peerDependencies, workspaceNames, newVersion);
+
   fs.writeFileSync(
     packageJsonPath,
     JSON.stringify(packageJson, null, 2) + '\n',
     'utf8'
   );
-  
+
   console.log(`Updated ${path.relative(rootDir, packageJsonPath)}: ${oldVersion} -> ${newVersion}`);
   return true;
 }
 
 function updateAllVersions(newVersion) {
   console.log(`Updating all package versions to ${newVersion}...\n`);
-  
+
+  // Collect workspace package names first (before modifying files)
+  const workspaceNames = getWorkspacePackageNames();
+  console.log(`Found ${workspaceNames.size} workspace packages: ${[...workspaceNames].join(', ')}\n`);
+
   // Update root package.json
-  updatePackageVersion(rootDir, newVersion);
-  
+  updatePackageVersion(rootDir, newVersion, workspaceNames);
+
   // Update all package.json files in packages/
   const packages = fs.readdirSync(packagesDir, { withFileTypes: true })
     .filter(dirent => dirent.isDirectory())
     .map(dirent => path.join(packagesDir, dirent.name));
-  
+
   let updatedCount = 0;
   for (const packagePath of packages) {
-    if (updatePackageVersion(packagePath, newVersion)) {
+    if (updatePackageVersion(packagePath, newVersion, workspaceNames)) {
       updatedCount++;
     }
   }
-  
-  console.log(`\nUpdated ${updatedCount + 1} package.json files`);
+
+  console.log(`\nUpdated ${updatedCount + 1} package.json files (versions + workspace deps)`);
 }
 
 // Main execution


### PR DESCRIPTION
## Summary

- Fixes release CI failure where `npm install --package-lock-only` fails with `ETARGET` for workspace packages
- Root cause: `update-versions.js` bumped `version` fields but left `dependencies` cross-references at the old version (e.g. `^0.18.0`), causing npm to try resolving unpublished versions from the registry
- Fix: the script now discovers all workspace package names and updates `dependencies`, `devDependencies`, and `peerDependencies` cross-references to `^{newVersion}`

## Test plan

- [x] Ran `node scripts/update-versions.js 0.19.0` locally — all 8 packages updated correctly
- [x] Verified `npm install --package-lock-only` succeeds after version bump
- [x] Verified cross-references (`@package-broker/core`, etc.) are rewritten to `^0.19.0`
- [ ] CI green