### PR TITLE
fix(core): resolve mirror dist 404s for branch (dev) versions

### DIFF
--- a/packages/core/src/__tests__/dist-utils.test.ts
+++ b/packages/core/src/__tests__/dist-utils.test.ts
@@ -4,9 +4,24 @@
  * Licensed under AGPL-3.0
  */
 
-import { describe, it, expect } from 'vitest';
-import { normalizeVersionToDisplay, findVersionInMetadata } from '../routes/dist';
+import { describe, it, expect, vi } from 'vitest';
+import type { Context } from 'hono';
+import { normalizeVersionToDisplay, findVersionInMetadata, distRoute } from '../routes/dist';
 import { deriveVersionNormalized } from '../routes/composer';
+
+vi.mock('../utils/logger', () => ({
+  getLogger: () => ({
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  }),
+}));
+
+vi.mock('../utils/analytics', () => ({
+  getAnalytics: () => ({
+    trackPackageDownload: vi.fn(),
+  }),
+}));
 
 describe('normalizeVersionToDisplay', () => {
   describe('patch versions', () => {
@@ -85,6 +100,44 @@ describe('normalizeVersionToDisplay', () => {
       expect(normalizeVersionToDisplay('1.0.0.0-patch10')).toBe('1.0.0-p10');
       expect(normalizeVersionToDisplay('1.0.0.0-patch99')).toBe('1.0.0-p99');
     });
+  });
+
+  describe('branch dev versions', () => {
+    it('should convert Composer normalized branch versions back to display versions', () => {
+      expect(normalizeVersionToDisplay('1.9999999.9999999.9999999-dev')).toBe('1.x-dev');
+      expect(normalizeVersionToDisplay('2.2.9999999.9999999-dev')).toBe('2.2.x-dev');
+      expect(normalizeVersionToDisplay('5.4.9999999.9999999-dev')).toBe('5.4.x-dev');
+      expect(normalizeVersionToDisplay('4.9999999.9999999.9999999-dev')).toBe('4.x-dev');
+    });
+
+    it('should leave dev branch names unchanged', () => {
+      expect(normalizeVersionToDisplay('dev-master')).toBe('dev-master');
+    });
+  });
+});
+
+describe('deriveVersionNormalized', () => {
+  it('should normalize numeric branch display versions like Composer', () => {
+    expect(deriveVersionNormalized('1.x-dev')).toBe('1.9999999.9999999.9999999-dev');
+    expect(deriveVersionNormalized('2.2.x-dev')).toBe('2.2.9999999.9999999-dev');
+    expect(deriveVersionNormalized('5.4.x-dev')).toBe('5.4.9999999.9999999-dev');
+    expect(deriveVersionNormalized('3.x-dev')).toBe('3.9999999.9999999.9999999-dev');
+    expect(deriveVersionNormalized('1.24.x-dev')).toBe('1.24.9999999.9999999-dev');
+    expect(deriveVersionNormalized('5.x-dev')).toBe('5.9999999.9999999.9999999-dev');
+  });
+
+  it('should leave literal dev branches unchanged', () => {
+    expect(deriveVersionNormalized('dev-master')).toBe('dev-master');
+    expect(deriveVersionNormalized('dev-main')).toBe('dev-main');
+  });
+
+  it('should preserve existing classical version normalization', () => {
+    expect(deriveVersionNormalized('v1.2.3')).toBe('1.2.3.0');
+    expect(deriveVersionNormalized('1.2')).toBe('1.2.0.0');
+    expect(deriveVersionNormalized('1.2-dev')).toBe('1.2.0.0-dev');
+    expect(deriveVersionNormalized('10.0-dev')).toBe('10.0.0.0-dev');
+    expect(deriveVersionNormalized('103.0.7-p8')).toBe('103.0.7.0-patch8');
+    expect(deriveVersionNormalized('2.2.1-beta')).toBe('2.2.1.0-beta');
   });
 });
 
@@ -267,5 +320,152 @@ describe('findVersionInMetadata', () => {
       expect(result).not.toBeNull();
       expect(result?.version).toBe('1.2.3-beta.1');
     });
+
+    it('should match minified metadata branch versions without version_normalized', () => {
+      const versions = [
+        {
+          version: '1.x-dev',
+          metadata: { dist: { url: 'https://example.com/1x.zip', type: 'zip' } },
+        },
+        {
+          version: 'v1.29.0',
+          metadata: { dist: { url: 'https://example.com/v129.zip', type: 'zip' } },
+        },
+      ];
+      const result = findVersionInMetadata(
+        '1.9999999.9999999.9999999-dev',
+        '1.x-dev',
+        versions
+      );
+      expect(result).not.toBeNull();
+      expect(result?.version).toBe('1.x-dev');
+    });
+
+    it('should match minified metadata minor branch versions without version_normalized', () => {
+      const versions = [
+        {
+          version: '2.2.x-dev',
+          metadata: { dist: { url: 'https://example.com/22x.zip', type: 'zip' } },
+        },
+      ];
+      const result = findVersionInMetadata(
+        '2.2.9999999.9999999-dev',
+        '2.2.x-dev',
+        versions
+      );
+      expect(result).not.toBeNull();
+      expect(result?.version).toBe('2.2.x-dev');
+    });
+
+    it('should not match an unrelated normalized branch version', () => {
+      const versions = [
+        {
+          version: '1.x-dev',
+          metadata: { dist: { url: 'https://example.com/1x.zip', type: 'zip' } },
+        },
+      ];
+      const result = findVersionInMetadata(
+        '9.9999999.9999999.9999999-dev',
+        '9.x-dev',
+        versions
+      );
+      expect(result).toBeNull();
+    });
+  });
+});
+
+describe('distRoute mirror branch version resolution', () => {
+  it('should resolve a normalized mirror URL version to a stored pretty branch version', async () => {
+    const artifact = {
+      id: 'artifact-1',
+      repo_id: 'repo-1',
+      package_name: 'symfony/polyfill-ctype',
+      version: '1.x-dev',
+      file_key: 'private/repo-1/symfony/polyfill-ctype/1.x-dev.zip',
+      size: 11,
+      download_count: 0,
+      created_at: 1_700_000_000,
+      last_downloaded_at: null,
+    };
+    const packageRow = {
+      id: 'pkg-1',
+      repo_id: 'repo-1',
+      name: 'symfony/polyfill-ctype',
+      version: '1.x-dev',
+      dist_url: 'https://broker.example/dist/repo-1/symfony/polyfill-ctype/1.x-dev.zip',
+      source_dist_url: 'https://example.com/source.zip',
+      dist_reference: 'abc123',
+      description: null,
+      license: null,
+      package_type: null,
+      homepage: null,
+      released_at: null,
+      readme_content: null,
+      metadata: JSON.stringify({ dist: { type: 'zip' } }),
+      is_manual_upload: 0,
+      created_at: 1_700_000_000,
+    };
+    const selectResults = [
+      [],
+      [{ repo_id: 'repo-1', version: '1.x-dev' }],
+      [artifact],
+      [packageRow],
+    ];
+    const select = vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve(selectResults.shift() ?? [])),
+        })),
+      })),
+    }));
+    const update = vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => Promise.resolve()),
+      })),
+    }));
+    const storageGet = vi.fn(() => Promise.resolve(new Response('zip-content').body));
+    const context = {
+      req: {
+        param: (key: string) => {
+          if (key === 'vendor') return 'symfony';
+          if (key === 'package') return 'polyfill-ctype';
+          if (key === 'version') return '1.9999999.9999999.9999999-dev.zip';
+          return undefined;
+        },
+        header: () => undefined,
+        url: 'https://broker.example/dist/m/symfony/polyfill-ctype/1.9999999.9999999.9999999-dev.zip',
+      },
+      env: {
+        ENCRYPTION_KEY: 'test-key',
+        KV: {},
+      },
+      var: {
+        storage: {
+          get: storageGet,
+          put: vi.fn(),
+          delete: vi.fn(),
+          exists: vi.fn(),
+        },
+      },
+      executionCtx: {
+        waitUntil: vi.fn(),
+      },
+      get: (key: string) => {
+        if (key === 'database') {
+          return { select, update };
+        }
+        if (key === 'requestId') {
+          return 'request-1';
+        }
+        return undefined;
+      },
+      json: vi.fn((data: unknown, status: number) => new Response(JSON.stringify(data), { status })),
+    } as unknown as Context;
+
+    const response = await distRoute(context);
+
+    expect(response.status).toBe(200);
+    expect(storageGet).toHaveBeenCalledWith('private/repo-1/symfony/polyfill-ctype/1.x-dev.zip');
+    expect(select).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/core/src/routes/composer.ts
+++ b/packages/core/src/routes/composer.ts
@@ -808,10 +808,73 @@ export function buildP2Response(
 }
 
 export function deriveVersionNormalized(version: string): string | undefined {
-  const v = version.startsWith('v') ? version.slice(1) : version;
+  const v = version.trim();
+
+  if (v.startsWith('dev-')) {
+    return v;
+  }
+
+  const versionWithoutV = v.startsWith('v') ? v.slice(1) : v;
+
+  const isNumericSegment = (part: string): boolean => {
+    if (part.length === 0) {
+      return false;
+    }
+
+    for (let i = 0; i < part.length; i++) {
+      const ch = part.charCodeAt(i);
+      if (ch < 48 || ch > 57) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  const normalizeBranchName = (branchName: string): string | undefined => {
+    const branchWithoutV = branchName.startsWith('v') ? branchName.slice(1) : branchName;
+    const parts = branchWithoutV.split('.');
+
+    if (parts.length < 1 || parts.length > 4) {
+      return undefined;
+    }
+
+    const normalizedParts: string[] = [];
+    for (const part of parts) {
+      if (isNumericSegment(part)) {
+        normalizedParts.push(part);
+      } else if (part === 'x' || part === 'X' || part === '*') {
+        normalizedParts.push('9999999');
+      } else {
+        return undefined;
+      }
+    }
+
+    while (normalizedParts.length < 4) {
+      normalizedParts.push('9999999');
+    }
+
+    return `${normalizedParts.join('.')}-dev`;
+  };
+
+  const lowerVersion = versionWithoutV.toLowerCase();
+  let branchName: string | null = null;
+  if (lowerVersion.endsWith('-dev') || lowerVersion.endsWith('.dev')) {
+    branchName = versionWithoutV.slice(0, -4);
+  }
+
+  if (branchName) {
+    if (branchName.includes('x') || branchName.includes('X') || branchName.includes('*')) {
+      const normalizedBranch = normalizeBranchName(branchName);
+      if (normalizedBranch) {
+        return normalizedBranch;
+      }
+    }
+
+  }
 
   // Handle patch versions (e.g., "103.0.7-p8" → "103.0.7.0-patch8")
-  const patchMatch = v.match(/^(\d+\.\d+\.\d+)-p(\d+)$/);
+  const patchMatch = versionWithoutV.match(/^(\d+\.\d+\.\d+)-p(\d+)$/);
   if (patchMatch) {
     const [, base, patch] = patchMatch;
     return `${base}.0-patch${patch}`;
@@ -821,14 +884,14 @@ export function deriveVersionNormalized(version: string): string | undefined {
   // 1. Parse up to 4 numeric segments separated by dots from the start of the string.
   // 2. Treat everything after the parsed numeric part as the suffix (e.g., "-beta", "-alpha", "-dev").
   let index = 0;
-  const length = v.length;
+  const length = versionWithoutV.length;
   const segments: string[] = [];
 
   while (index < length && segments.length < 4) {
     const start = index;
     // Read a numeric segment
     while (index < length) {
-      const ch = v.charCodeAt(index);
+      const ch = versionWithoutV.charCodeAt(index);
       if (ch < 48 || ch > 57) { // not '0'–'9'
         break;
       }
@@ -838,7 +901,7 @@ export function deriveVersionNormalized(version: string): string | undefined {
       // No digits found where a segment was expected
       break;
     }
-    segments.push(v.slice(start, index));
+    segments.push(versionWithoutV.slice(start, index));
 
     // If we have 4 segments or we've reached the end, stop
     if (segments.length === 4 || index >= length) {
@@ -846,7 +909,7 @@ export function deriveVersionNormalized(version: string): string | undefined {
     }
 
     // Expect a dot between segments; if not present, stop parsing numeric part
-    if (v[index] === '.') {
+    if (versionWithoutV[index] === '.') {
       index++;
       continue;
     }
@@ -855,7 +918,7 @@ export function deriveVersionNormalized(version: string): string | undefined {
 
   if (segments.length > 0) {
     const [major, minor = '0', patch = '0', build = '0'] = segments;
-    const suffix = v.slice(index); // everything after the numeric part
+    const suffix = versionWithoutV.slice(index); // everything after the numeric part
     return `${major}.${minor}.${patch}.${build}${suffix}`;
   }
 

--- a/packages/core/src/routes/dist.ts
+++ b/packages/core/src/routes/dist.ts
@@ -209,6 +209,23 @@ function extractVersionFromParam(versionParam: string | undefined): string {
 }
 
 export function normalizeVersionToDisplay(version: string): string {
+  if (version.endsWith('-dev')) {
+    const versionPart = version.slice(0, -4);
+    const parts = versionPart.split('.');
+    const firstWildcardIndex = parts.indexOf('9999999');
+
+    if (
+      firstWildcardIndex > 0 &&
+      parts.length <= 4 &&
+      parts.slice(0, firstWildcardIndex).every((part) => /^\d+$/.test(part)) &&
+      parts.slice(firstWildcardIndex).every((part) => part === '9999999')
+    ) {
+      const displayParts = parts.slice(0, firstWildcardIndex);
+      displayParts.push('x');
+      return `${displayParts.join('.')}-dev`;
+    }
+  }
+
   const patchMatch = version.match(/^(\d+\.\d+\.\d+)\.0-patch(\d+)$/);
   if (patchMatch) {
     const [, base, patch] = patchMatch;


### PR DESCRIPTION
## Problem

Composer clients installing branch versions (`1.x-dev`, `5.4.x-dev`, `2.2.x-dev`, …) through the broker mirror receive 404s from `/dist/m/...` and silently fall back to upstream. Observed in production:

```
Failed downloading symfony/polyfill-ctype, trying the next URL
(404: https://<broker>/dist/m/symfony/polyfill-ctype/1.9999999.9999999.9999999-dev.zip)
{"error":"Not Found","message":"Version not found in repository"}
```

The install only succeeds because Composer retries the original upstream dist URL — the mirror is effectively bypassed for every dev package, so CI keeps hammering upstream and the broker's caching value is lost for those packages.

## Root cause

Composer substitutes `%version%` in the mirror `dist-url` template with the **normalized** version (`getVersion()`). For branches that is the 9999999-padded form (`1.x-dev` → `1.9999999.9999999.9999999-dev`). The dist route could not resolve that form at any layer:

1. DB lookup uses the stored pretty version (`1.x-dev`) → miss.
2. `normalizeVersionToDisplay()` only reversed `.0`-style 4th segments, not branch forms → second lookup miss.
3. Lazy-load matching depends on `deriveVersionNormalized()`, which mangled branch versions: `deriveVersionNormalized('1.x-dev')` returned `1.0.0.0x-dev` instead of Composer's `1.9999999.9999999.9999999-dev` (see `composer/semver` `VersionParser::normalizeBranch`). Packagist v2 minified metadata carries no `version_normalized`, so this was the only match path → 404.

## Fix

- `deriveVersionNormalized` (`packages/core/src/routes/composer.ts`): Composer-faithful branch normalization — `x`/`X`/`*` segments → `9999999`, pad to 4 segments, keep `-dev`; `dev-*` branch names pass through unchanged. Classical dev pre-releases are untouched (`1.2-dev` → `1.2.0.0-dev`), so published `version_normalized` metadata stays correct for real `N.N-dev` releases.
- `normalizeVersionToDisplay` (`packages/core/src/routes/dist.ts`): reverse mapping for 9999999-padded forms (`2.2.9999999.9999999-dev` → `2.2.x-dev`) so the primary DB lookup now hits for mirrored branch versions.

## Tests

- `deriveVersionNormalized`: all production incident shapes (`1.x-dev`, `2.2.x-dev`, `5.4.x-dev`, `3.x-dev`, `1.24.x-dev`, `5.x-dev`), `dev-master`/`dev-main` passthrough, classical forms preserved (`v1.2.3`, `103.0.7-p8`, `2.2.1-beta`, `1.2-dev`).
- `normalizeVersionToDisplay`: reverse branch mapping + existing display cases.
- `findVersionInMetadata`: matching against Packagist-minified metadata entries **without** `version_normalized`, positive and negative cases.
- Mirror route regression: request for `1.9999999.9999999.9999999-dev` resolves a package stored as `1.x-dev`.

`npm test` 22 files / 244 tests green, `npm run lint` 0 errors, `npm run typecheck` clean.

## Follow-up (out of scope)

The mirror template lacks `%reference%`, so mutable branches can still serve an artifact older than the commit Composer resolved. Needs a separate change (template + `/r<ref>` handling in the dist route).