### PR TITLE
ci(config): real-source E2E on PRs — Docker + Workers, Packagist/Mage-OS/Magento

### DIFF
--- a/.github/workflows/real-source-e2e.yml
+++ b/.github/workflows/real-source-e2e.yml
@@ -1,0 +1,157 @@
+name: Real Source E2E
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: real-source-e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    name: Docker / Node real-source E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      BROKER_URL: http://localhost:3000
+      EXPECT_DEV_VERSION_FIX: "false" # Known bug: flip to true after fix/dev-version-mirroring lands.
+      MAGENTO_AVAILABLE: ${{ secrets.MAGENTO_PUBLIC_KEY != '' && secrets.MAGENTO_PRIVATE_KEY != '' && 'true' || 'false' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
+          coverage: none
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.server
+          tags: package-broker-server:real-source-e2e
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Start Docker broker
+        run: |
+          set -euo pipefail
+          CONTAINER_ID=$(docker run -d \
+            -p 3000:3000 \
+            -e DB_DRIVER=sqlite \
+            -e DB_URL="/data/real-source-e2e.db" \
+            -e STORAGE_DRIVER=fs \
+            -e STORAGE_PATH="/data/storage" \
+            -e CACHE_DRIVER=memory \
+            -e QUEUE_DRIVER=memory \
+            -e ENCRYPTION_KEY="test-encryption-key-32-bytes-long" \
+            package-broker-server:real-source-e2e)
+          echo "BROKER_DOCKER_CONTAINER=$CONTAINER_ID" >> "$GITHUB_ENV"
+          echo "BROKER_LOG_FILE=$RUNNER_TEMP/docker-broker.log" >> "$GITHUB_ENV"
+          docker logs -f "$CONTAINER_ID" > "$RUNNER_TEMP/docker-broker.log" 2>&1 &
+
+      - name: Run real-source E2E without Magento credentials
+        if: env.MAGENTO_AVAILABLE != 'true'
+        run: node scripts/real-source-e2e.mjs "$BROKER_URL"
+
+      - name: Run real-source E2E with Magento credentials
+        if: env.MAGENTO_AVAILABLE == 'true'
+        run: node scripts/real-source-e2e.mjs "$BROKER_URL"
+        env:
+          MAGENTO_PUBLIC_KEY: ${{ secrets.MAGENTO_PUBLIC_KEY }}
+          MAGENTO_PRIVATE_KEY: ${{ secrets.MAGENTO_PRIVATE_KEY }}
+
+      - name: Print Docker broker logs on failure
+        if: failure()
+        run: docker logs --tail 300 "$BROKER_DOCKER_CONTAINER" || true
+
+      - name: Stop Docker broker
+        if: always()
+        run: |
+          if [ -n "${BROKER_DOCKER_CONTAINER:-}" ]; then
+            docker rm -f "$BROKER_DOCKER_CONTAINER" || true
+          fi
+
+  workers:
+    name: Cloudflare Workers real-source E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      BROKER_URL: http://localhost:8787
+      EXPECT_DEV_VERSION_FIX: "false" # Known bug: flip to true after fix/dev-version-mirroring lands.
+      MAGENTO_AVAILABLE: ${{ secrets.MAGENTO_PUBLIC_KEY != '' && secrets.MAGENTO_PRIVATE_KEY != '' && 'true' || 'false' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
+          coverage: none
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build UI assets
+        run: npm run build -w packages/ui
+
+      - name: Apply local D1 migrations
+        run: npm run db:migrate
+
+      - name: Start Workers broker
+        run: |
+          set -euo pipefail
+          echo "BROKER_LOG_FILE=$RUNNER_TEMP/wrangler-broker.log" >> "$GITHUB_ENV"
+          CHOKIDAR_USEPOLLING=1 npx wrangler dev -c wrangler.dev.toml --local --port 8787 --live-reload=false --show-interactive-dev-session=false > "$RUNNER_TEMP/wrangler-broker.log" 2>&1 &
+          echo "WRANGLER_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Run real-source E2E without Magento credentials
+        if: env.MAGENTO_AVAILABLE != 'true'
+        run: node scripts/real-source-e2e.mjs "$BROKER_URL"
+
+      - name: Run real-source E2E with Magento credentials
+        if: env.MAGENTO_AVAILABLE == 'true'
+        run: node scripts/real-source-e2e.mjs "$BROKER_URL"
+        env:
+          MAGENTO_PUBLIC_KEY: ${{ secrets.MAGENTO_PUBLIC_KEY }}
+          MAGENTO_PRIVATE_KEY: ${{ secrets.MAGENTO_PRIVATE_KEY }}
+
+      - name: Print Workers broker logs on failure
+        if: failure()
+        run: |
+          if [ -n "${BROKER_LOG_FILE:-}" ] && [ -f "$BROKER_LOG_FILE" ]; then
+            tail -300 "$BROKER_LOG_FILE"
+          fi
+
+      - name: Stop Workers broker
+        if: always()
+        run: |
+          if [ -n "${WRANGLER_PID:-}" ]; then
+            kill "$WRANGLER_PID" || true
+          fi

--- a/.github/workflows/real-source-e2e.yml
+++ b/.github/workflows/real-source-e2e.yml
@@ -30,12 +30,12 @@ jobs:
         with:
           node-version: '22.x'
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          tools: composer
-          coverage: none
+      - name: Verify preinstalled PHP and Composer
+        # ubuntu-latest runners ship PHP 8.3 + Composer; shivammathur/setup-php
+        # is not on the org Actions allowlist, so rely on the runner image.
+        run: |
+          php --version
+          composer --version
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -108,12 +108,12 @@ jobs:
           node-version: '22.x'
           cache: 'npm'
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          tools: composer
-          coverage: none
+      - name: Verify preinstalled PHP and Composer
+        # ubuntu-latest runners ship PHP 8.3 + Composer; shivammathur/setup-php
+        # is not on the org Actions allowlist, so rely on the runner image.
+        run: |
+          php --version
+          composer --version
 
       - name: Install dependencies
         run: npm ci

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "npm run build -w packages/shared && npm run build -w packages/core && npm run build -w packages/ui && npm run build -w packages/main && npm run build -w packages/cli && npm run build -w packages/cloudflare && npm run build -w packages/adapter-node",
     "dev": "cd packages/ui && npm run build && cd ../.. && npx wrangler dev -c wrangler.dev.toml --local --port 8787",
-    "db:migrate": "npx wrangler d1 execute package-broker-db --local --file=./packages/main/migrations/0001_initial.sql -c wrangler.dev.toml",
+    "db:migrate": "npx wrangler d1 migrations apply package-broker-db --local -c wrangler.dev.toml",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -108,6 +108,8 @@ async function start() {
                 (c.env as any) = {
                     ...(c.env || {}),
                     ENCRYPTION_KEY: encryptionKey,
+                    KV: cache,
+                    QUEUE: queue,
                     // Pass SMTP configuration from process.env
                     SMTP_HOST: process.env.SMTP_HOST,
                     SMTP_PORT: process.env.SMTP_PORT,

--- a/packages/core/src/__tests__/security-advisories.test.ts
+++ b/packages/core/src/__tests__/security-advisories.test.ts
@@ -264,21 +264,37 @@ describe('securityAdvisoriesPlugin', () => {
   });
 
   it('should subscribe to package.synced events', async () => {
-    const ctx: PluginContext<any, any> = {
-      services: new ServiceContainer(),
-      events: new EventBus(),
-      hooks: new HookRegistry(),
-    };
+    // The plugin's event handler queries the Packagist advisories API with
+    // the default global fetch — stub it so the test never hits the network.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(SAMPLE_ADVISORIES_RESPONSE), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
 
-    await loadPlugin(securityAdvisoriesPlugin as any, ctx);
+    try {
+      const ctx: PluginContext<any, any> = {
+        services: new ServiceContainer(),
+        events: new EventBus(),
+        hooks: new HookRegistry(),
+      };
 
-    // Emit a package.synced event — should not throw
-    await expect(
-      ctx.events.emit('package.synced', {
-        packageName: 'safe/package',
-        version: '1.0.0',
-      }),
-    ).resolves.toBeUndefined();
+      await loadPlugin(securityAdvisoriesPlugin as any, ctx);
+
+      // Emit a package.synced event — should not throw
+      await expect(
+        ctx.events.emit('package.synced', {
+          packageName: 'safe/package',
+          version: '1.0.0',
+        }),
+      ).resolves.toBeUndefined();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('should add a sync observer', async () => {

--- a/packages/core/src/middleware/auth.ts
+++ b/packages/core/src/middleware/auth.ts
@@ -7,6 +7,7 @@ import type { DatabasePort } from '../ports';
 import { tokens, tokenScopes } from '../db/schema';
 import { eq } from 'drizzle-orm';
 import { TokenScopeService } from '../services/TokenScopeService';
+import { runInBackground } from '../utils/background';
 
 const VALID_SCOPE_TYPES = new Set(['repository', 'package_pattern']);
 
@@ -198,7 +199,8 @@ export async function distAuthMiddleware(
 
     // Cache for 5 seconds to handle burst requests (only if rate limiting is enabled)
     if (tokenRecord) {
-      c.executionCtx.waitUntil(
+      runInBackground(
+        c,
         c.env.KV.put(cacheKey, JSON.stringify(tokenRecord), { expirationTtl: 5 }).catch(() => {
           // Ignore cache errors
         })
@@ -233,7 +235,8 @@ export async function distAuthMiddleware(
   });
 
   // Update last_used_at (non-blocking)
-  c.executionCtx.waitUntil(
+  runInBackground(
+    c,
     (async () => {
       const db = c.get('database');
       if (c.env.QUEUE && typeof c.env.QUEUE.send === 'function') {
@@ -324,7 +327,8 @@ export async function authMiddleware(
 
     // Cache for 5 seconds to handle burst requests (only if rate limiting is enabled)
     if (tokenRecord) {
-      c.executionCtx.waitUntil(
+      runInBackground(
+        c,
         c.env.KV.put(cacheKey, JSON.stringify(tokenRecord), { expirationTtl: 5 }).catch(() => {
           // Ignore cache errors
         })
@@ -392,7 +396,7 @@ export async function authMiddleware(
   };
 
   // Run in background to not block the response
-  c.executionCtx.waitUntil(updateTokenLastUsed());
+  runInBackground(c, updateTokenLastUsed());
 
   return await next();
 }

--- a/packages/core/src/routes/composer.ts
+++ b/packages/core/src/routes/composer.ts
@@ -18,6 +18,7 @@ import { nanoid } from 'nanoid';
 import { encryptCredentials } from '../utils/encryption';
 import { getLogger } from '../utils/logger';
 import { getAnalytics } from '../utils/analytics';
+import { runInBackground } from '../utils/background';
 
 export interface ComposerRouteEnv {
   Bindings: {
@@ -59,7 +60,7 @@ function schedulePackageStorage(
 
   if (workflow) {
     // Use Cloudflare Workflow for durable background processing
-    c.executionCtx.waitUntil((async () => {
+    runInBackground(c, (async () => {
       try {
         const instance = await workflow.create({
           id: `pkg-${packageName.replace('/', '-')}-${repoId}-${Date.now()}`,
@@ -95,7 +96,7 @@ function schedulePackageStorage(
     })());
   } else {
     // Inline background processing
-    c.executionCtx.waitUntil((async () => {
+    runInBackground(c, (async () => {
       try {
         const db = c.get('database');
         const { storedCount, errors } = await transformPackageDistUrls(packageData, repoId, baseUrl, db);
@@ -174,7 +175,7 @@ export async function packagesJsonRoute(c: Context<ComposerRouteEnv>): Promise<R
   // Cache the result (fire-and-forget to avoid blocking on KV rate limits)
   const cachingEnabled = await isPackageCachingEnabled(c.env.KV);
   if (cachingEnabled && c.env.KV) {
-    c.executionCtx.waitUntil(
+    runInBackground(c,
       Promise.all([
         c.env.KV.put(kvKey, JSON.stringify(packagesJson)).catch(() => { }),
         c.env.KV.put(metadataKey, JSON.stringify({ lastModified: Date.now() })).catch(() => { })
@@ -309,6 +310,7 @@ export async function lazyLoadPackageFromRepositories(
   
   if (mirroringEnabled) {
     try {
+      await ensurePackagistRepository(db, encryptionKey, kv || undefined);
       const packagistUrl = `https://repo.packagist.org/p2/${packageName}.json`;
       const response = await fetch(packagistUrl, {
         headers: {
@@ -377,7 +379,7 @@ export async function p2PackageRoute(c: Context<ComposerRouteEnv>): Promise<Resp
         logger.warn('Invalid cache format (not an object or old format), treating as cache miss', { packageName });
         // Fire-and-forget cache deletion
         if (c.env.KV) {
-          c.executionCtx.waitUntil(
+          runInBackground(c,
             Promise.all([
               c.env.KV.delete(kvKey).catch(() => { }),
               c.env.KV.delete(metadataKey).catch(() => { })
@@ -412,7 +414,7 @@ export async function p2PackageRoute(c: Context<ComposerRouteEnv>): Promise<Resp
       logger.warn('Invalid JSON in cache, treating as cache miss', { packageName, error: e instanceof Error ? e.message : String(e) });
       // Fire-and-forget cache deletion
       if (c.env.KV) {
-        c.executionCtx.waitUntil(
+        runInBackground(c,
           Promise.all([
             c.env.KV.delete(kvKey).catch(() => { }),
             c.env.KV.delete(metadataKey).catch(() => { })
@@ -438,7 +440,7 @@ export async function p2PackageRoute(c: Context<ComposerRouteEnv>): Promise<Resp
     // Cache the result (fire-and-forget to avoid blocking on KV rate limits)
     const cachingEnabled = await isPackageCachingEnabled(c.env.KV);
     if (cachingEnabled && c.env.KV) {
-      c.executionCtx.waitUntil(
+      runInBackground(c,
         Promise.all([
           c.env.KV.put(kvKey, JSON.stringify(packageData)).catch(() => { }),
           c.env.KV.put(metadataKey, JSON.stringify({ lastModified: Date.now() })).catch(() => { })

--- a/packages/core/src/routes/dist.ts
+++ b/packages/core/src/routes/dist.ts
@@ -22,6 +22,7 @@ import { getAnalytics } from '../utils/analytics';
 import { type AuthContext } from '../middleware/auth';
 import { lazyLoadPackageFromRepositories, normalizePackageVersions, storePackageInDB, deriveVersionNormalized } from './composer';
 import { computeShasum } from '../utils/checksum';
+import { runInBackground } from '../utils/background';
 
 export interface DistRouteEnv {
   Bindings: {
@@ -507,7 +508,7 @@ export async function distRoute(c: Context<DistRouteEnv>): Promise<Response> {
                 logger.info('Successfully stored Packagist artifact in storage', { storageKey, size: totalSize, packageName, version });
 
                 if (computedShasum) {
-                  c.executionCtx.waitUntil(
+                  runInBackground(c,
                     (async () => {
                       try {
                         const [pkg] = await db
@@ -553,7 +554,7 @@ export async function distRoute(c: Context<DistRouteEnv>): Promise<Response> {
                   );
                 }
 
-                c.executionCtx.waitUntil(
+                runInBackground(c,
                   extractAndStoreReadme(
                     storage,
                     combined,
@@ -572,7 +573,7 @@ export async function distRoute(c: Context<DistRouteEnv>): Promise<Response> {
               const now = Math.floor(Date.now() / 1000);
               if (artifact) {
                 // Update existing artifact record
-                c.executionCtx.waitUntil(
+                runInBackground(c,
                   db
                     .update(artifacts)
                     .set({
@@ -588,7 +589,7 @@ export async function distRoute(c: Context<DistRouteEnv>): Promise<Response> {
               } else {
                 // Create new artifact record
                 const artifactId = nanoid();
-                c.executionCtx.waitUntil(
+                runInBackground(c,
                   db
                     .insert(artifacts)
                     .values({
@@ -724,7 +725,7 @@ export async function distRoute(c: Context<DistRouteEnv>): Promise<Response> {
                 await storage.put(storageKey, arrayBuffer);
                 
                 if (computedShasum && pkg) {
-                  c.executionCtx.waitUntil(
+                  runInBackground(c,
                     (async () => {
                       try {
                         const metadata = pkg.metadata ? JSON.parse(pkg.metadata) : {};
@@ -752,7 +753,7 @@ export async function distRoute(c: Context<DistRouteEnv>): Promise<Response> {
                   );
                 }
                 
-                c.executionCtx.waitUntil(
+                runInBackground(c,
                   extractAndStoreReadme(
                     storage,
                     combined,
@@ -786,14 +787,14 @@ export async function distRoute(c: Context<DistRouteEnv>): Promise<Response> {
               };
 
               if (artifact) {
-                c.executionCtx.waitUntil(
+                runInBackground(c,
                   db.update(artifacts)
                     .set({ size: totalSize, created_at: now })
                     .where(eq(artifacts.id, artifact.id))
                     .catch(() => { })
                 );
               } else {
-                c.executionCtx.waitUntil(
+                runInBackground(c,
                   db.insert(artifacts)
                     .values({ ...artifactData, download_count: 0 })
                     .onConflictDoNothing()
@@ -842,7 +843,7 @@ export async function distRoute(c: Context<DistRouteEnv>): Promise<Response> {
       };
 
       // Run in background to not block the response
-      c.executionCtx.waitUntil(updateDownloadCount());
+      runInBackground(c, updateDownloadCount());
     }
 
     // Get dist.type from package metadata to determine Content-Type
@@ -1112,7 +1113,7 @@ export async function distRoute(c: Context<DistRouteEnv>): Promise<Response> {
         computedShasum = computeShasum(combined);
       }
 
-      c.executionCtx.waitUntil(
+      runInBackground(c,
         (async () => {
           try {
             const arrayBuffer = combined.buffer.slice(
@@ -1211,7 +1212,7 @@ export async function distRoute(c: Context<DistRouteEnv>): Promise<Response> {
 
   // Update download count (non-blocking)
   if (artifact) {
-    c.executionCtx.waitUntil(
+    runInBackground(c,
       (async () => {
         if (c.env.QUEUE && typeof c.env.QUEUE.send === 'function') {
           await c.env.QUEUE.send({

--- a/packages/core/src/utils/background.ts
+++ b/packages/core/src/utils/background.ts
@@ -1,0 +1,15 @@
+export interface BackgroundContext {
+  executionCtx: {
+    waitUntil(promise: Promise<unknown>): void;
+  };
+}
+
+export function runInBackground(c: BackgroundContext, promise: Promise<unknown>): void {
+  try {
+    c.executionCtx.waitUntil(promise);
+  } catch {
+    promise.catch(() => {
+      // Ignore background task failures in runtimes without waitUntil.
+    });
+  }
+}

--- a/packages/main/migrations/0007_add_manual_upload_flag.sql
+++ b/packages/main/migrations/0007_add_manual_upload_flag.sql
@@ -1,8 +1,7 @@
--- Add is_manual_upload flag to packages table
--- This field marks packages that were manually uploaded vs synced from repositories
+-- Historical no-op: is_manual_upload is already part of the packages schema
+-- in 0001_initial.sql (snapshot) and the packages rebuild in
+-- 0004_fix_package_unique.sql, so re-adding the column breaks fresh databases.
+-- Databases that applied the original version of this migration have it
+-- recorded in d1_migrations and never re-run it.
 
-ALTER TABLE packages ADD COLUMN is_manual_upload INTEGER DEFAULT 0 NOT NULL;
-
--- Index for filtering manual uploads
-CREATE INDEX idx_packages_manual_upload ON packages(is_manual_upload);
-
+CREATE INDEX IF NOT EXISTS idx_packages_manual_upload ON packages(is_manual_upload);

--- a/scripts/real-source-e2e.mjs
+++ b/scripts/real-source-e2e.mjs
@@ -1,0 +1,552 @@
+#!/usr/bin/env node
+import { mkdtemp, readFile, writeFile, rm, access, stat, mkdir } from 'node:fs/promises';
+import { constants as fsConstants, createWriteStream } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+
+const brokerUrl = process.argv[2]?.replace(/\/$/, '');
+
+if (!brokerUrl || brokerUrl === '--help' || brokerUrl === '-h') {
+  console.error('Usage: scripts/real-source-e2e.mjs <broker-url>');
+  process.exit(brokerUrl ? 0 : 2);
+}
+
+const adminEmail = process.env.REAL_SOURCE_E2E_ADMIN_EMAIL || 'real-source-e2e@example.test';
+const adminPassword = process.env.REAL_SOURCE_E2E_ADMIN_PASSWORD || 'real-source-e2e-password';
+const expectDevVersionFix = /^1|true|yes$/i.test(process.env.EXPECT_DEV_VERSION_FIX || '');
+const keepTemp = /^1|true|yes$/i.test(process.env.REAL_SOURCE_E2E_KEEP_TEMP || '');
+const composerTimeoutMs = Number(process.env.REAL_SOURCE_E2E_COMPOSER_TIMEOUT_MS || 180000);
+const brokerHost = new URL(brokerUrl).host;
+const runId = Date.now().toString(36);
+
+const sources = [
+  {
+    id: 'packagist',
+    label: 'Public Packagist mirroring',
+    setup: 'packagist-mirroring',
+    requires: [
+      {
+        id: 'packagist-stable',
+        packageName: 'monolog/monolog',
+        constraint: '^3.0',
+        vendorFile: 'vendor/monolog/monolog/src/Monolog/Logger.php',
+      },
+    ],
+  },
+  {
+    id: 'packagist-dev-version',
+    label: 'Public Packagist dev branch version regression',
+    setup: 'packagist-mirroring',
+    softFailUnless: () => expectDevVersionFix,
+    softFailMessage:
+      'Known bug: dev branch dist mirroring can request /dist/m/.../1.9999999.9999999.9999999-dev.zip and 404. Set EXPECT_DEV_VERSION_FIX=true to make this a hard failure.',
+    requires: [
+      {
+        id: 'packagist-dev-version',
+        packageName: 'symfony/polyfill-ctype',
+        constraint: '1.x-dev',
+        vendorFile: 'vendor/symfony/polyfill-ctype/bootstrap.php',
+      },
+    ],
+  },
+  {
+    id: 'mage-os',
+    label: 'Mage-OS mirror',
+    repository: {
+      url: 'https://mirror.mage-os.org',
+      vcs_type: 'composer',
+      credential_type: 'none',
+      auth_credentials: {},
+      package_filter: 'magento/composer-root-update-plugin',
+    },
+    requires: [
+      {
+        id: 'mage-os-small-package',
+        packageName: 'magento/composer-root-update-plugin',
+        constraint: '2.0.6',
+        ignorePlatformReqs: true,
+        vendorFile: 'vendor/magento/composer-root-update-plugin/composer.json',
+      },
+    ],
+  },
+  {
+    id: 'magento',
+    label: 'Magento Composer Repository',
+    enabled: () => Boolean(process.env.MAGENTO_PUBLIC_KEY && process.env.MAGENTO_PRIVATE_KEY),
+    skipMessage: 'Skipping repo.magento.com source because Magento credentials are not available.',
+    repository: {
+      url: 'https://repo.magento.com',
+      vcs_type: 'composer',
+      credential_type: 'http_basic',
+      auth_credentials: () => ({
+        username: process.env.MAGENTO_PUBLIC_KEY,
+        password: process.env.MAGENTO_PRIVATE_KEY,
+      }),
+      package_filter: 'magento/composer',
+    },
+    requires: [
+      {
+        id: 'magento-auth-package',
+        packageName: 'magento/composer',
+        constraint: '1.9.0',
+        ignorePlatformReqs: true,
+        vendorFile: 'vendor/magento/composer/composer.json',
+      },
+    ],
+  },
+];
+
+let adminToken = '';
+let apiToken = '';
+let projectDir = '';
+let lastComposerLog = '';
+let failureContext = null;
+
+process.on('unhandledRejection', (error) => {
+  fail(error);
+});
+
+try {
+  await waitForHealth();
+  adminToken = await bootstrapAdmin();
+  await enablePackagistMirroring();
+  await createConfiguredRepositories();
+  apiToken = await createApiToken();
+
+  projectDir = await mkdtemp(join(tmpdir(), 'package-broker-real-source-e2e-'));
+  await writeComposerProject(projectDir);
+
+  for (const source of sources) {
+    if (source.enabled && !source.enabled()) {
+      warning(source.skipMessage);
+      continue;
+    }
+
+    await runSource(source);
+  }
+
+  console.log('Real-source E2E completed.');
+} catch (error) {
+  await fail(error);
+} finally {
+  if (projectDir && !keepTemp) {
+    await rm(projectDir, { recursive: true, force: true }).catch(() => {});
+  } else if (projectDir) {
+    console.error(`Keeping temp Composer project: ${projectDir}`);
+  }
+}
+
+async function runSource(source) {
+  console.log(`\n== ${source.label} ==`);
+
+  for (const requireSpec of source.requires) {
+    failureContext = { source, requireSpec };
+
+    try {
+      await composerRequire(requireSpec);
+      await assertVendorFile(requireSpec.vendorFile);
+      const lock = await readComposerLock();
+      assertLockContainsBrokerDist(lock, requireSpec.packageName);
+      await assertBrokerPackageExists(requireSpec.packageName);
+      console.log(`PASS ${source.id}: ${requireSpec.packageName}`);
+    } catch (error) {
+      if (source.softFailUnless && !source.softFailUnless()) {
+        warning(`${source.softFailMessage}\nSoft-failed step: ${source.id} / ${requireSpec.packageName}\n${error.stack || error.message || error}`);
+        continue;
+      }
+      throw error;
+    } finally {
+      failureContext = null;
+    }
+  }
+}
+
+async function waitForHealth() {
+  const deadline = Date.now() + Number(process.env.REAL_SOURCE_E2E_HEALTH_TIMEOUT_MS || 90000);
+  let lastError;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${brokerUrl}/health`);
+      if (response.ok) {
+        console.log(`Broker health is OK at ${brokerUrl}`);
+        return;
+      }
+      lastError = new Error(`Health returned HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(1500);
+  }
+
+  throw new Error(`Broker did not become healthy at ${brokerUrl}: ${lastError?.message || 'timeout'}`);
+}
+
+async function bootstrapAdmin() {
+  const check = await api('/api/auth/check');
+  if (check.setupRequired) {
+    await api('/api/setup', {
+      method: 'POST',
+      body: { email: adminEmail, password: adminPassword },
+    });
+    console.log('Initial admin setup completed.');
+  }
+
+  const login = await api('/api/auth/login', {
+    method: 'POST',
+    body: { email: adminEmail, password: adminPassword },
+  });
+
+  if (!login.token) {
+    throw new Error('Login did not return an admin session token.');
+  }
+
+  return login.token;
+}
+
+async function enablePackagistMirroring() {
+  const result = await api('/api/settings/packagist-mirroring', {
+    method: 'PUT',
+    admin: true,
+    body: { enabled: true },
+  });
+
+  if (result.packagist_mirroring_enabled !== true) {
+    throw new Error('Packagist mirroring was not enabled.');
+  }
+}
+
+async function createConfiguredRepositories() {
+  const existing = await api('/api/repositories', { admin: true });
+  const existingByUrl = new Map(existing.map((repo) => [repo.url.replace(/\/$/, ''), repo]));
+
+  for (const source of sources) {
+    if (!source.repository || (source.enabled && !source.enabled())) {
+      continue;
+    }
+
+    const payload = {
+      ...source.repository,
+      auth_credentials:
+        typeof source.repository.auth_credentials === 'function'
+          ? source.repository.auth_credentials()
+          : source.repository.auth_credentials,
+    };
+    const repoKey = payload.url.replace(/\/$/, '');
+    const repo = existingByUrl.get(repoKey) || await api('/api/repositories', {
+      method: 'POST',
+      admin: true,
+      body: payload,
+    });
+
+    await api(`/api/repositories/${encodeURIComponent(repo.id)}/sync`, {
+      method: 'POST',
+      admin: true,
+    });
+    console.log(`Repository ready: ${source.id} (${payload.url})`);
+  }
+}
+
+async function createApiToken() {
+  const tokenResponse = await api('/api/tokens', {
+    method: 'POST',
+    admin: true,
+    body: {
+      description: `real-source-e2e-${runId}`,
+      permissions: 'readonly',
+      rate_limit_max: null,
+    },
+  });
+
+  if (!tokenResponse.token) {
+    throw new Error('Token API did not return a Composer token.');
+  }
+
+  return tokenResponse.token;
+}
+
+async function writeComposerProject(dir) {
+  await mkdir(join(dir, '.composer-home'), { recursive: true });
+  await mkdir(join(dir, '.composer-cache'), { recursive: true });
+  await writeFile(join(dir, '.composer-home', 'composer.json'), '{}');
+  await writeFile(join(dir, 'composer.json'), JSON.stringify({
+    name: 'package-broker/real-source-e2e-consumer',
+    description: 'Temporary consumer project for PACKAGE.broker real-source E2E.',
+    type: 'project',
+    'minimum-stability': 'dev',
+    'prefer-stable': true,
+    repositories: [
+      { type: 'composer', url: brokerUrl },
+      { packagist: false },
+    ],
+    config: {
+      'secure-http': brokerUrl.startsWith('https://'),
+      'allow-plugins': false,
+      'preferred-install': 'dist',
+    },
+  }, null, 2));
+}
+
+async function composerRequire(requireSpec) {
+  const args = [
+    'require',
+    `${requireSpec.packageName}:${requireSpec.constraint}`,
+    '--update-with-all-dependencies',
+    '--prefer-dist',
+    '--no-interaction',
+    '--no-progress',
+    '--no-plugins',
+    '-vvv',
+  ];
+
+  if (requireSpec.ignorePlatformReqs) {
+    args.push('--ignore-platform-reqs');
+  }
+
+  const env = {
+    ...process.env,
+    COMPOSER_HOME: join(projectDir, '.composer-home'),
+    COMPOSER_CACHE_DIR: join(projectDir, '.composer-cache'),
+    COMPOSER_AUTH: JSON.stringify({
+      'http-basic': {
+        [brokerHost]: {
+          username: 'token',
+          password: apiToken,
+        },
+      },
+    }),
+    COMPOSER_ALLOW_SUPERUSER: '1',
+  };
+
+  const output = await retryCommand('composer', args, {
+    cwd: projectDir,
+    env,
+    timeoutMs: composerTimeoutMs,
+    attempts: 3,
+  });
+
+  assertNoComposerFallback(output);
+  assertComposerDownloadedThroughBroker(output, requireSpec.packageName);
+}
+
+async function retryCommand(command, args, options) {
+  let lastError;
+  for (let attempt = 1; attempt <= options.attempts; attempt += 1) {
+    try {
+      return await runCommand(command, args, options);
+    } catch (error) {
+      lastError = error;
+      if (attempt >= options.attempts) {
+        break;
+      }
+      warning(`${command} ${args.join(' ')} failed on attempt ${attempt}; retrying once more after a short delay.`);
+      await sleep(3000 * attempt);
+    }
+  }
+  throw lastError;
+}
+
+async function runCommand(command, args, { cwd, env, timeoutMs }) {
+  const logFile = join(tmpdir(), `package-broker-real-source-e2e-${runId}-${sanitizeFileName(args.join('-'))}.log`);
+  lastComposerLog = logFile;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, env, stdio: ['ignore', 'pipe', 'pipe'] });
+    const log = createWriteStream(logFile);
+    const chunks = [];
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      setTimeout(() => child.kill('SIGKILL'), 5000).unref();
+    }, timeoutMs);
+
+    child.stdout.on('data', (chunk) => {
+      chunks.push(chunk);
+      log.write(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      chunks.push(chunk);
+      log.write(chunk);
+    });
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      log.end();
+      reject(error);
+    });
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      log.end();
+      const output = Buffer.concat(chunks).toString('utf8');
+      if (code === 0) {
+        resolve(output);
+        return;
+      }
+      const reason = signal ? `signal ${signal}` : `exit code ${code}`;
+      reject(new Error(`${command} ${args.join(' ')} failed with ${reason}. Log: ${logFile}\n${tail(output)}`));
+    });
+  });
+}
+
+function assertNoComposerFallback(output) {
+  const fallbackPattern = /Failed downloading|trying the next URL/i;
+  if (fallbackPattern.test(output)) {
+    throw new Error(`Composer attempted fallback to another URL.\n${tail(output)}`);
+  }
+}
+
+function assertComposerDownloadedThroughBroker(output, packageName) {
+  const relevantLines = output
+    .split(/\r?\n/)
+    .filter((line) => /Downloading|Loading|Reading|Writing/i.test(line) && line.includes(packageName.split('/')[0]));
+  const attemptedDownloadLines = output
+    .split(/\r?\n/)
+    .filter((line) => /Downloading .*\.zip|Following redirect|Writing .* into cache/i.test(line));
+
+  if (attemptedDownloadLines.length > 0 && !attemptedDownloadLines.some((line) => line.includes(brokerHost))) {
+    throw new Error(`Composer download output did not show broker host ${brokerHost}.\n${tail(attemptedDownloadLines.join('\n') || relevantLines.join('\n') || output)}`);
+  }
+}
+
+async function assertVendorFile(relativePath) {
+  try {
+    await access(join(projectDir, relativePath), fsConstants.R_OK);
+  } catch {
+    throw new Error(`Expected installed vendor file is missing: ${relativePath}`);
+  }
+}
+
+async function readComposerLock() {
+  const lockPath = join(projectDir, 'composer.lock');
+  try {
+    const contents = await readFile(lockPath, 'utf8');
+    return JSON.parse(contents);
+  } catch (error) {
+    throw new Error(`Could not read composer.lock: ${error.message}`);
+  }
+}
+
+function assertLockContainsBrokerDist(lock, packageName) {
+  const installed = [...(lock.packages || []), ...(lock['packages-dev'] || [])].filter((pkg) => pkg.name === packageName);
+  if (installed.length === 0) {
+    throw new Error(`composer.lock does not contain ${packageName}`);
+  }
+
+  const hasBrokerMirror = installed.some((pkg) => {
+    const distUrl = pkg.dist?.url || '';
+    const mirrors = Array.isArray(pkg.dist?.mirrors) ? pkg.dist.mirrors : [];
+    return distUrl.includes(brokerHost) || mirrors.some((mirror) => String(mirror.url || '').includes(brokerHost));
+  });
+
+  if (!hasBrokerMirror) {
+    throw new Error(`composer.lock for ${packageName} does not contain broker dist URL or mirror host ${brokerHost}`);
+  }
+}
+
+async function assertBrokerPackageExists(packageName) {
+  const result = await api(`/api/packages?search=${encodeURIComponent(packageName)}&limit=100`, { admin: true });
+  const packages = Array.isArray(result.data) ? result.data : [];
+  if (!packages.some((pkg) => pkg.name === packageName)) {
+    throw new Error(`Broker package API does not list mirrored package ${packageName}`);
+  }
+}
+
+async function api(path, options = {}) {
+  const method = options.method || 'GET';
+  const headers = {
+    Accept: 'application/json',
+  };
+
+  if (options.body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
+  if (options.admin) {
+    headers.Authorization = `Bearer ${adminToken}`;
+  }
+
+  const response = await fetch(`${brokerUrl}${path}`, {
+    method,
+    headers,
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  });
+
+  const text = await response.text();
+  let json = null;
+  if (text) {
+    try {
+      json = JSON.parse(text);
+    } catch {
+      json = { raw: text };
+    }
+  }
+
+  if (!response.ok) {
+    throw new Error(`${method} ${path} returned HTTP ${response.status}: ${text}`);
+  }
+
+  return json;
+}
+
+async function fail(error) {
+  console.error('\nReal-source E2E failed.');
+  if (failureContext) {
+    console.error(`Source: ${failureContext.source.id}`);
+    console.error(`Package: ${failureContext.requireSpec.packageName}`);
+  }
+  console.error(error?.stack || error?.message || error);
+
+  await printFileTail('Composer output', lastComposerLog);
+  await printFileTail('Broker log', process.env.BROKER_LOG_FILE);
+
+  if (process.env.BROKER_DOCKER_CONTAINER) {
+    await runBestEffort('docker', ['logs', '--tail', '200', process.env.BROKER_DOCKER_CONTAINER]);
+  }
+
+  process.exitCode = 1;
+}
+
+async function printFileTail(label, file) {
+  if (!file) {
+    return;
+  }
+  try {
+    const fileStat = await stat(file);
+    if (!fileStat.isFile()) {
+      return;
+    }
+    const contents = await readFile(file, 'utf8');
+    console.error(`\n--- ${label}: ${file} (tail) ---`);
+    console.error(tail(contents, 200));
+  } catch {
+    // Ignore missing logs.
+  }
+}
+
+async function runBestEffort(command, args) {
+  try {
+    const output = await runCommand(command, args, {
+      cwd: process.cwd(),
+      env: process.env,
+      timeoutMs: 30000,
+    });
+    console.error(`\n--- ${command} ${args.join(' ')} ---`);
+    console.error(output);
+  } catch (error) {
+    console.error(`Could not collect ${command} ${args.join(' ')}: ${error.message}`);
+  }
+}
+
+function tail(value, lines = 120) {
+  return String(value || '').split(/\r?\n/).slice(-lines).join('\n');
+}
+
+function sanitizeFileName(value) {
+  return value.replace(/[^a-z0-9._-]+/gi, '-').slice(0, 120);
+}
+
+function warning(message) {
+  console.warn(`::warning::${message}`);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/wrangler.dev.toml
+++ b/wrangler.dev.toml
@@ -12,6 +12,7 @@ LOG_LEVEL = "debug"
 binding = "DB"
 database_name = "package-broker-db"
 database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+migrations_dir = "packages/main/migrations"
 
 # KV Namespace for caching
 [[kv_namespaces]]


### PR DESCRIPTION
## Summary

Every PR now proves the broker actually mirrors and serves real packages on **both supported runtimes**, consumed by a **real PHP/Composer process** — not just unit-level checks.

## What runs on each PR

Two jobs (`.github/workflows/real-source-e2e.yml`):
- **Docker**: builds `Dockerfile.server`, boots the container (SQLite/fs/memory), runs the harness
- **Workers**: `wrangler dev --local` with local D1/KV/R2, applies migrations, runs the same harness

Shared harness (`scripts/real-source-e2e.mjs`, runnable locally: `node scripts/real-source-e2e.mjs http://localhost:PORT`): bootstraps admin, enables Packagist mirroring, creates repositories + scoped token via the HTTP API, then drives Composer with the broker as the **only** repository:

| Source | Package | Gate |
|---|---|---|
| Public Packagist | `monolog/monolog` | always |
| Packagist dev branch | `symfony/polyfill-ctype:1.x-dev` | regression for the production mirror-404 bug (#141); soft-fail with `::warning::` until the fix merges — then flip `EXPECT_DEV_VERSION_FIX=true` |
| Mage-OS mirror | `magento/composer-root-update-plugin` | always (auth-free, fork-PR safe) |
| repo.magento.com | gated | only when `MAGENTO_PUBLIC_KEY`/`MAGENTO_PRIVATE_KEY` secrets exist |

**Hard assertions**: zero `Failed downloading` / `trying the next URL` in Composer output (fallback to upstream = red), dist hosts must be the broker, vendor-dir spot checks, broker package API reflects mirrored state. Sources are config entries — GitHub/Bitbucket mirroring legs are one entry each later.

## Product fixes the suite immediately surfaced

- **`fix(core)`: Node runtime parity** — adapter-node never exposed `c.env.KV`/`c.env.QUEUE`, so token caching, rate limiting and queue paths silently no-oped on Docker; `executionCtx.waitUntil` throws on Node — new shared `runInBackground()` util degrades gracefully. Lazy Packagist loading now ensures the `packagist` repository row exists before writing metadata.
- **`fix(main)`: broken migration chain** — `db:migrate` applied only `0001_initial.sql` (fresh local D1 lacked `token_scopes`/`organizations`), and `0007` re-added a column already present in the `0001` snapshot and `0004` rebuild, failing every fresh migration run. Now `wrangler d1 migrations apply` with `migrations_dir`, and `0007` is a guarded historical no-op.

## Verification (all run locally)

- Docker leg: **pass** — Packagist ✓, Mage-OS ✓, dev-branch reproduces the 404 and soft-fails loudly ✓, Magento skipped (no keys) ✓
- Workers leg: **pass** — same results after the migration-chain fix
- `actionlint`: clean; `npm test` 235/235; lint 0 errors; typecheck clean

## Relation to other PRs

- #141 fixes the dev-branch 404 this suite reproduces — after it merges, flip `EXPECT_DEV_VERSION_FIX` default to `true`
- #142 moves CI to Node 22 — this workflow already uses `22.x`

## Security impact

New workflow runs with `permissions: contents: read` only, concurrency-cancelled per PR. Magento repo keys consumed exclusively via GitHub secrets, gated so fork PRs skip the leg; no secrets echoed to logs. The harness creates throwaway admin credentials inside disposable local broker instances only.