### PR TITLE
fix(release): use /data paths in Docker smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,9 +123,9 @@ jobs:
           CONTAINER_ID=$(docker run -d \
             -p 3000:3000 \
             -e DB_DRIVER=sqlite \
-            -e DB_URL="/tmp/test.db" \
+            -e DB_URL="/data/test.db" \
             -e STORAGE_DRIVER=fs \
-            -e STORAGE_PATH="/tmp/storage" \
+            -e STORAGE_PATH="/data/storage" \
             -e CACHE_DRIVER=memory \
             -e QUEUE_DRIVER=memory \
             -e ENCRYPTION_KEY="test-encryption-key-32-bytes-long" \
@@ -165,7 +165,8 @@ jobs:
           echo "Checking for runtime errors..."
           sleep 2  # Give it a moment to fully initialize
           
-          if docker logs $CONTAINER_ID 2>&1 | grep -iE "(error|exception|failed|cannot|uncaught|SyntaxError|TypeError)" | grep -v "WARN"; then
+          if docker logs $CONTAINER_ID 2>&1 | grep -iE "(error|exception|failed|cannot|uncaught|SyntaxError|TypeError)" | \
+             grep -v -iE "(database not initialized|warning|⚠️|WARN)"; then
             echo "❌ Found errors in container logs:"
             docker logs $CONTAINER_ID
             docker rm -f $CONTAINER_ID


### PR DESCRIPTION
## Problem

Release `v0.19.4` failed in **Validate Release → Test Docker image (smoke test)**:

```
ERROR: DB_URL must resolve to a path under /data/
```

`docker-entrypoint.sh` validates that `DB_URL` resolves under `/data/` (path-traversal guard). The smoke test used `DB_URL=/tmp/test.db`, so the container died at entrypoint — the second stale-env issue in this step (#145 fixed the missing `ENCRYPTION_KEY`; the `/tmp` paths were left in place, my omission — the env should have been mirrored from ci.yml wholesale).

## Fix

- `DB_URL` → `/data/test.db`, `STORAGE_PATH` → `/data/storage` — byte-identical env to the proven `ci.yml` "Test Docker Image" job (verified with diff)
- runtime-error log grep exclusions aligned with ci.yml (`database not initialized|warning|⚠️|WARN`) so benign init output cannot fail a release while CI stays green

## Entrypoint constraints audit

All `docker-entrypoint.sh` hard requirements now satisfied by the smoke env:
1. `ENCRYPTION_KEY` set — fixed in #145
2. `DB_URL` under `/data/` — this PR
3. Migrations write to `dirname(DB_URL)` — `/data` is writable in the image (CI proves it on every PR)

## Release path after merge

`fix:` commit bumps to `v0.19.5`; new tag runs the repaired workflow. Remaining unverified stages are npm OIDC publish and Docker Hub/GHCR push — those last ran green on 0.19.0-era releases and are untouched here.