### PR TITLE
fix(main): use explicit column list in 0004 packages rebuild

### DIFF
--- a/packages/main/migrations/0004_fix_package_unique.sql
+++ b/packages/main/migrations/0004_fix_package_unique.sql
@@ -18,7 +18,16 @@ CREATE TABLE packages_new (
   created_at INTEGER NOT NULL
 );
 
-INSERT INTO packages_new SELECT * FROM packages;
+-- Explicit column list: positional SELECT * corrupts databases where
+-- is_manual_upload was appended by the original 0007 ALTER TABLE (after
+-- created_at), which reverses the last two columns vs. this table.
+INSERT INTO packages_new (id, repo_id, name, version, dist_url, source_dist_url,
+  dist_reference, description, license, package_type, homepage, released_at,
+  readme_content, metadata, is_manual_upload, created_at)
+SELECT id, repo_id, name, version, dist_url, source_dist_url,
+  dist_reference, description, license, package_type, homepage, released_at,
+  readme_content, metadata, is_manual_upload, created_at
+FROM packages;
 DROP TABLE packages;
 ALTER TABLE packages_new RENAME TO packages;
 


### PR DESCRIPTION
## Problem

`0004_fix_package_unique.sql` rebuilds `packages` with `INSERT INTO packages_new SELECT * FROM packages` — **positional** column mapping. Databases that received `is_manual_upload` from the original 0007 `ALTER TABLE ADD COLUMN` have it as the **last** column (after `created_at`), reversed relative to `packages_new`. On those databases the rebuild silently swaps `created_at` ↔ `is_manual_upload` for every row: timestamps become flag values and vice versa.

The production D1 database (`package-broker-db`) is exactly in this state — verified via `PRAGMA table_info(packages)`: `created_at` = cid 14, `is_manual_upload` = cid 15 — and has 0004 pending.

## Fix

Explicit column lists on both INSERT and SELECT — name-based mapping, correct regardless of physical column order.

## Test plan

Simulated both layouts with sqlite3 and ran the migration file:
- production order (`..., created_at, is_manual_upload`) → values land in correct columns
- fresh 0001-snapshot order (`..., is_manual_upload, created_at`) → unchanged behavior

CI applies the migration chain on fresh databases on every PR (mocked E2E + real-source E2E).