### PR TITLE
fix(core): refresh stale package metadata and stop dropping sync jobs

### DIFF
--- a/packages/core/src/__tests__/composer-route.test.ts
+++ b/packages/core/src/__tests__/composer-route.test.ts
@@ -78,10 +78,91 @@ describe('p2PackageRoute', () => {
         // With the fix, the invalid cache should be ignored (treated as miss) and DELETED.
         expect(mockKv.delete).toHaveBeenCalledWith('p2:pdepend/pdepend~dev');
 
-        // Execution proceeds. Since our mock KV returns garbage for settings too, 
+        // Execution proceeds. Since our mock KV returns garbage for settings too,
         // mirroringEnabled will likely be false (checks if value === 'true' or null).
         // So it should eventually return 404 via c.json().
         // We check that it did NOT crash and proceeded past cache check.
         expect(mockContext.json).toHaveBeenCalled();
+    });
+
+    it('should cache DB responses with a TTL and schedule stale revalidation', async () => {
+        const packageRow = {
+            id: 'pkg1',
+            repo_id: 'repo1',
+            name: 'acme/widget',
+            version: '1.0.0',
+            dist_url: '/dist/repo1/acme/widget/1.0.0.zip',
+            source_dist_url: 'https://upstream.example.com/widget-1.0.0.zip',
+            dist_reference: 'ref',
+            description: null,
+            license: null,
+            package_type: null,
+            homepage: null,
+            released_at: 1700000000,
+            readme_content: null,
+            metadata: JSON.stringify({
+                name: 'acme/widget',
+                version: '1.0.0',
+                dist: { type: 'zip', url: 'https://upstream.example.com/widget-1.0.0.zip' },
+            }),
+            created_at: 1700000000,
+        };
+
+        const mockKv = {
+            get: vi.fn().mockResolvedValue(null),
+            put: vi.fn().mockResolvedValue(undefined),
+            delete: vi.fn().mockResolvedValue(undefined),
+        };
+
+        const backgroundPromises: Promise<unknown>[] = [];
+
+        const mockContext = {
+            req: {
+                param: (key: string) => {
+                    if (key === 'vendor') return 'acme';
+                    if (key === 'package') return 'widget.json';
+                    return undefined;
+                },
+                header: () => undefined,
+                url: 'http://localhost/p2/acme/widget.json',
+            },
+            env: {
+                KV: mockKv,
+                DB: {},
+                ENCRYPTION_KEY: 'key',
+            },
+            executionCtx: {
+                waitUntil: vi.fn((p: Promise<unknown>) => backgroundPromises.push(p)),
+            },
+            get: (key: string) => {
+                if (key === 'database') {
+                    return {
+                        select: vi.fn().mockReturnValue({
+                            from: vi.fn().mockReturnValue({
+                                where: vi.fn().mockResolvedValue([packageRow]),
+                            }),
+                        }),
+                    };
+                }
+                if (key === 'requestId') return 'req-123';
+                return undefined;
+            },
+            json: vi.fn((data, status) => new Response(JSON.stringify(data), { status })),
+        } as unknown as Context;
+
+        const response = await p2PackageRoute(mockContext);
+        await Promise.all(backgroundPromises);
+
+        expect(response.status).toBe(200);
+
+        // Cached p2 responses must expire so stale metadata cannot be served forever
+        expect(mockKv.put).toHaveBeenCalledWith(
+            'p2:acme/widget',
+            expect.any(String),
+            expect.objectContaining({ expirationTtl: expect.any(Number) })
+        );
+
+        // One background task scheduled: cache write chained with stale revalidation
+        expect(backgroundPromises.length).toBe(1);
     });
 });

--- a/packages/core/src/__tests__/jobs.test.ts
+++ b/packages/core/src/__tests__/jobs.test.ts
@@ -48,13 +48,55 @@ describe('Job Processor', () => {
     });
 
     describe('QueueJobProcessor', () => {
-        it('should send job to queue', async () => {
+        it('should send lightweight jobs to queue', async () => {
             const sendMock = vi.fn();
             const queueEnv = { ...mockEnv, QUEUE: { send: sendMock } as any };
             const processor = createJobProcessor(queueEnv);
 
-            await processor.enqueue({ type: 'sync_repository', repoId: '123' });
-            expect(sendMock).toHaveBeenCalledWith({ type: 'sync_repository', repoId: '123' });
+            await processor.enqueue({ type: 'update_token_last_used', tokenId: 'token1', timestamp: 123 });
+            expect(sendMock).toHaveBeenCalledWith({ type: 'update_token_last_used', tokenId: 'token1', timestamp: 123 });
+        });
+
+        it('should process sync_repository inline instead of queueing', async () => {
+            // The queue consumer has no request context (storage driver, proxy base URL),
+            // so sync jobs must run inline even when a queue producer is bound.
+            const sendMock = vi.fn();
+            const queueEnv = { ...mockEnv, QUEUE: { send: sendMock } as any };
+            const syncOptions = { storage: {} as any, proxyBaseUrl: 'url' };
+            const processor = createJobProcessor(queueEnv, { syncOptions });
+
+            vi.mocked(syncRepository).mockResolvedValue({ success: true, packages: [] });
+
+            await processor.enqueue({ type: 'sync_repository', repoId: 'repo1' });
+
+            expect(sendMock).not.toHaveBeenCalled();
+            expect(syncRepository).toHaveBeenCalledWith(
+                'repo1',
+                expect.objectContaining({ DB: mockEnv.DB }),
+                syncOptions
+            );
+        });
+
+        it('should split mixed batches between queue and inline execution', async () => {
+            const sendMock = vi.fn();
+            const queueEnv = { ...mockEnv, QUEUE: { send: sendMock } as any };
+            const syncOptions = { storage: {} as any, proxyBaseUrl: 'url' };
+            const processor = createJobProcessor(queueEnv, { syncOptions });
+
+            vi.mocked(syncRepository).mockResolvedValue({ success: true, packages: [] });
+
+            await processor.enqueueAll([
+                { type: 'sync_repository', repoId: 'repo1' },
+                { type: 'update_token_last_used', tokenId: 'token1', timestamp: 123 },
+            ]);
+
+            expect(sendMock).toHaveBeenCalledTimes(1);
+            expect(sendMock).toHaveBeenCalledWith({ type: 'update_token_last_used', tokenId: 'token1', timestamp: 123 });
+            expect(syncRepository).toHaveBeenCalledWith(
+                'repo1',
+                expect.objectContaining({ DB: mockEnv.DB }),
+                syncOptions
+            );
         });
     });
 
@@ -89,7 +131,7 @@ describe('Job Processor', () => {
             const syncOptions = { storage: {} as any, proxyBaseUrl: 'url' };
             const processor = createJobProcessor(mockEnv, { syncOptions });
 
-            (syncRepository as any).mockResolvedValue({ success: true, packages: [] });
+            vi.mocked(syncRepository).mockResolvedValue({ success: true, packages: [] });
 
             await processor.enqueue({ type: 'sync_repository', repoId: 'repo1' });
 

--- a/packages/core/src/__tests__/package-revalidation.test.ts
+++ b/packages/core/src/__tests__/package-revalidation.test.ts
@@ -1,0 +1,140 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { revalidateStalePackage } from '../routes/package-revalidation';
+
+vi.mock('../utils/logger', () => ({
+    getLogger: () => ({
+        warn: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+    }),
+}));
+
+describe('revalidateStalePackage', () => {
+    const packageName = 'magento/product-community-edition';
+    const repoRow = { id: 'repo-1', url: 'https://repo.example.com', vcs_type: 'composer' };
+    const upstreamData = { packages: { [packageName]: [{ version: '2.4.7-p10' }] } };
+
+    let mockDb: any;
+    let mockCache: {
+        get: ReturnType<typeof vi.fn>;
+        put: ReturnType<typeof vi.fn>;
+        delete: ReturnType<typeof vi.fn>;
+    };
+    let loadPackageFromRepo: ReturnType<typeof vi.fn>;
+    let storePackages: ReturnType<typeof vi.fn>;
+
+    const runRevalidation = (overrides: Partial<Parameters<typeof revalidateStalePackage>[0]> = {}) =>
+        revalidateStalePackage({
+            db: mockDb,
+            cache: mockCache as any,
+            packageName,
+            repoIds: ['repo-1'],
+            encryptionKey: 'key',
+            proxyBaseUrl: 'https://broker.example.com',
+            loadPackageFromRepo: loadPackageFromRepo as any,
+            storePackages: storePackages as any,
+            ...overrides,
+        });
+
+    beforeEach(() => {
+        mockDb = {
+            select: vi.fn().mockReturnValue({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockResolvedValue([repoRow]),
+                }),
+            }),
+        };
+        mockCache = {
+            get: vi.fn().mockResolvedValue(null),
+            put: vi.fn().mockResolvedValue(undefined),
+            delete: vi.fn().mockResolvedValue(undefined),
+        };
+        loadPackageFromRepo = vi.fn().mockResolvedValue(upstreamData);
+        storePackages = vi.fn().mockResolvedValue({ transformed: {}, storedCount: 1, errors: [] });
+    });
+
+    it('refreshes changed metadata from the original repo and purges the cached response', async () => {
+        await runRevalidation();
+
+        expect(loadPackageFromRepo).toHaveBeenCalledWith(repoRow, packageName, 'key');
+        expect(storePackages).toHaveBeenCalledWith(
+            upstreamData,
+            'repo-1',
+            'https://broker.example.com',
+            mockDb
+        );
+        expect(mockCache.delete).toHaveBeenCalledWith(`p2:${packageName}`);
+        expect(mockCache.delete).toHaveBeenCalledWith(`p2:${packageName}:metadata`);
+    });
+
+    it('records a content hash so unchanged upstream data is not re-stored', async () => {
+        await runRevalidation();
+
+        const hashKey = `p2:${packageName}:repo-1:content-hash`;
+        const [key, storedHash] = mockCache.put.mock.calls[0];
+        expect(key).toBe(hashKey);
+
+        // Second cycle: upstream returns identical content, hash matches
+        mockCache.get.mockResolvedValue(storedHash);
+        storePackages.mockClear();
+        mockCache.delete.mockClear();
+
+        await runRevalidation();
+
+        expect(storePackages).not.toHaveBeenCalled();
+        expect(mockCache.delete).not.toHaveBeenCalled();
+    });
+
+    it('does not store or purge when upstream has no data', async () => {
+        loadPackageFromRepo.mockResolvedValue(null);
+
+        await runRevalidation();
+
+        expect(storePackages).not.toHaveBeenCalled();
+        expect(mockCache.put).not.toHaveBeenCalled();
+        expect(mockCache.delete).not.toHaveBeenCalled();
+    });
+
+    it('dedupes concurrent revalidations of the same package', async () => {
+        let release!: () => void;
+        loadPackageFromRepo.mockImplementation(
+            () => new Promise((resolve) => {
+                release = () => resolve(null);
+            })
+        );
+
+        const first = runRevalidation();
+        const second = runRevalidation();
+        await second; // returns immediately - already in flight
+
+        expect(loadPackageFromRepo).toHaveBeenCalledTimes(1);
+        release();
+        await first;
+
+        // After completion the package can be revalidated again
+        loadPackageFromRepo.mockResolvedValue(null);
+        await runRevalidation();
+        expect(loadPackageFromRepo).toHaveBeenCalledTimes(2);
+    });
+
+    it('only contacts the repos the stored rows came from', async () => {
+        const whereMock = vi.fn().mockResolvedValue([repoRow]);
+        mockDb.select = vi.fn().mockReturnValue({
+            from: vi.fn().mockReturnValue({ where: whereMock }),
+        });
+
+        await runRevalidation({ repoIds: ['repo-1'] });
+
+        // The repos query is scoped to the given ids, not the full table
+        expect(whereMock).toHaveBeenCalled();
+        expect(loadPackageFromRepo).toHaveBeenCalledTimes(1);
+        expect(loadPackageFromRepo).toHaveBeenCalledWith(repoRow, packageName, 'key');
+    });
+});

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -57,3 +57,25 @@ describe('Download Utils', () => {
             .rejects.toThrow('Authentication failed');
     });
 });
+
+describe('parseGitHubOwnerRepo', () => {
+    it('parses https URLs and drops the .git suffix', async () => {
+        const { parseGitHubOwnerRepo } = await import('../utils/upstream-fetch');
+        expect(parseGitHubOwnerRepo('https://github.com/Weltpixel/magento2-weltpixel-backend.git'))
+            .toEqual({ owner: 'Weltpixel', repoName: 'magento2-weltpixel-backend' });
+    });
+
+    it('parses ssh URLs', async () => {
+        const { parseGitHubOwnerRepo } = await import('../utils/upstream-fetch');
+        expect(parseGitHubOwnerRepo('git@github.com:acme/widget.git'))
+            .toEqual({ owner: 'acme', repoName: 'widget' });
+    });
+
+    it('rejects non-GitHub and malformed URLs', async () => {
+        const { parseGitHubOwnerRepo } = await import('../utils/upstream-fetch');
+        expect(parseGitHubOwnerRepo('https://gitlab.com/acme/widget')).toBeNull();
+        expect(parseGitHubOwnerRepo('https://github.com')).toBeNull();
+        expect(parseGitHubOwnerRepo('https://github.com/acme')).toBeNull();
+        expect(parseGitHubOwnerRepo('https://github.com//widget')).toBeNull();
+    });
+});

--- a/packages/core/src/jobs/processor.ts
+++ b/packages/core/src/jobs/processor.ts
@@ -68,27 +68,38 @@ export function createJobProcessor(
   env: JobEnv,
   options?: { syncOptions?: SyncOptions }
 ): JobProcessor {
+  const syncProcessor = new SyncJobProcessor(env, options?.syncOptions);
   if (env.QUEUE && typeof env.QUEUE.send === 'function') {
-    return new QueueJobProcessor(env.QUEUE);
+    return new QueueJobProcessor(env.QUEUE, syncProcessor);
   }
-  return new SyncJobProcessor(env, options?.syncOptions);
+  return syncProcessor;
 }
 
 /**
  * Queue-based job processor - sends jobs to Cloudflare Queue
  * Jobs are processed asynchronously by queue consumers
+ *
+ * sync_repository jobs are the exception: they need request-scoped context
+ * (storage driver, proxy base URL) that a queue consumer does not have, so
+ * they always run inline via the SyncJobProcessor fallback.
  */
 class QueueJobProcessor implements JobProcessor {
-  constructor(private queue: Queue) { }
+  constructor(
+    private queue: Queue,
+    private inlineProcessor: SyncJobProcessor
+  ) { }
 
   async enqueue(job: Job): Promise<void> {
+    if (job.type === 'sync_repository') {
+      await this.inlineProcessor.enqueue(job);
+      return;
+    }
     await this.queue.send(job);
   }
 
   async enqueueAll(jobs: Job[]): Promise<void> {
-    // Queue supports batch sending
     for (const job of jobs) {
-      await this.queue.send(job);
+      await this.enqueue(job);
     }
   }
 }

--- a/packages/core/src/queue/consumer.ts
+++ b/packages/core/src/queue/consumer.ts
@@ -75,27 +75,6 @@ export async function processQueueMessage(
   }
 }
 
-/**
- * Queue consumer worker entry point
- * This will be called by Cloudflare Queue when messages are available
- */
-export default {
-  async queue(batch: MessageBatch<QueueMessage>, env: QueueConsumerEnv): Promise<void> {
-    // Process messages in batch (optimize for free tier)
-    const promises = batch.messages.map((msg) => {
-      try {
-        return processQueueMessage(msg.body, env);
-      } catch (error) {
-        const logger = getLogger();
-        logger.error('Error processing queue message', { messageType: msg.body.type }, error instanceof Error ? error : new Error(String(error)));
-        // Don't retry on error - log and continue
-        return Promise.resolve();
-      }
-    });
-
-    await Promise.all(promises);
-  },
-};
 
 
 

--- a/packages/core/src/queue/index.ts
+++ b/packages/core/src/queue/index.ts
@@ -1,2 +1,4 @@
 
 export * from './memory-driver';
+export * from './types';
+export { processQueueMessage, type QueueConsumerEnv } from './consumer';

--- a/packages/core/src/routes/composer.ts
+++ b/packages/core/src/routes/composer.ts
@@ -19,6 +19,7 @@ import { encryptCredentials } from '../utils/encryption';
 import { getLogger } from '../utils/logger';
 import { getAnalytics } from '../utils/analytics';
 import { runInBackground } from '../utils/background';
+import { revalidateStalePackage, REVALIDATION_TTL_SECONDS } from './package-revalidation';
 
 export interface ComposerRouteEnv {
   Bindings: {
@@ -172,9 +173,12 @@ export async function packagesJsonRoute(c: Context<ComposerRouteEnv>): Promise<R
   // No cache - build packages.json from database
   const packagesJson = await buildPackagesJson(c);
 
-  // Cache the result (fire-and-forget to avoid blocking on KV rate limits)
+  // Cache the result (fire-and-forget to avoid blocking on KV rate limits).
+  // Never cache while repository syncs are pending or in flight: the list is
+  // built from pre-sync data and would otherwise be pinned in KV until the
+  // next manual purge.
   const cachingEnabled = await isPackageCachingEnabled(c.env.KV);
-  if (cachingEnabled && c.env.KV) {
+  if (cachingEnabled && c.env.KV && !hasPendingRepos) {
     runInBackground(c,
       Promise.all([
         c.env.KV.put(kvKey, JSON.stringify(packagesJson)).catch(() => { }),
@@ -233,6 +237,45 @@ function matchesPackageFilter(packageName: string, filter: string | null): boole
 }
 
 /**
+ * Fetch package metadata from a single repository, dispatching on vcs_type.
+ * Returns the raw upstream package data, or null when the repo does not
+ * provide the package (filter mismatch, unsupported host, not found).
+ */
+export async function fetchPackageFromRepository(
+  repo: typeof repositories.$inferSelect,
+  packageName: string,
+  encryptionKey: string
+): Promise<any | null> {
+  if (!matchesPackageFilter(packageName, repo.package_filter)) {
+    return null;
+  }
+
+  const repoRef = {
+    id: repo.id,
+    url: repo.url,
+    vcs_type: repo.vcs_type,
+    credential_type: repo.credential_type,
+    auth_credentials: repo.auth_credentials,
+    package_filter: repo.package_filter,
+  };
+
+  if (repo.vcs_type === 'composer') {
+    const { fetchPackageFromUpstream } = await import('../utils/upstream-fetch');
+    return fetchPackageFromUpstream(repoRef, packageName, encryptionKey);
+  }
+
+  if (repo.vcs_type === 'git') {
+    const { fetchPackageFromGitHub, isGitHubUrl } = await import('../utils/upstream-fetch');
+    if (!isGitHubUrl(repo.url)) {
+      return null;
+    }
+    return fetchPackageFromGitHub(repoRef, packageName, encryptionKey);
+  }
+
+  return null;
+}
+
+/**
  * Lazy load package metadata from all available repositories
  * Returns package data and repo_id if found, null otherwise
  */
@@ -251,56 +294,18 @@ export async function lazyLoadPackageFromRepositories(
 
   for (const repo of sortedRepos) {
     try {
-      if (!matchesPackageFilter(packageName, repo.package_filter)) {
-        continue;
-      }
-
-      let packageData = null;
-      
-      if (repo.vcs_type === 'composer') {
-        const { fetchPackageFromUpstream } = await import('../utils/upstream-fetch');
-        packageData = await fetchPackageFromUpstream(
-          {
-            id: repo.id,
-            url: repo.url,
-            vcs_type: repo.vcs_type,
-            credential_type: repo.credential_type,
-            auth_credentials: repo.auth_credentials,
-            package_filter: repo.package_filter,
-          },
-          packageName,
-          encryptionKey
-        );
-      } else if (repo.vcs_type === 'git') {
-        const { fetchPackageFromGitHub, isGitHubUrl } = await import('../utils/upstream-fetch');
-        
-        if (!isGitHubUrl(repo.url)) {
-          continue;
-        }
-        packageData = await fetchPackageFromGitHub(
-          {
-            id: repo.id,
-            url: repo.url,
-            vcs_type: repo.vcs_type,
-            credential_type: repo.credential_type,
-            auth_credentials: repo.auth_credentials,
-            package_filter: repo.package_filter,
-          },
-          packageName,
-          encryptionKey
-        );
-      }
+      const packageData = await fetchPackageFromRepository(repo, packageName, encryptionKey);
 
       if (packageData) {
         return { packageData, repoId: repo.id };
       }
     } catch (error) {
       const logger = getLogger();
-      logger.warn('Error fetching package from repo', { 
-        packageName, 
-        repoId: repo.id, 
+      logger.warn('Error fetching package from repo', {
+        packageName,
+        repoId: repo.id,
         vcsType: repo.vcs_type,
-        error: error instanceof Error ? error.message : String(error) 
+        error: error instanceof Error ? error.message : String(error)
       });
     }
   }
@@ -342,7 +347,8 @@ export async function lazyLoadPackageFromRepositories(
 export async function p2PackageRoute(c: Context<ComposerRouteEnv>): Promise<Response> {
   const vendor = c.req.param('vendor');
   const packageFile = c.req.param('package');
-  const packageName = `${vendor}/${packageFile?.replace('.json', '')}`;
+  // Strip only the trailing extension - package names may contain ".json"
+  const packageName = `${vendor}/${packageFile?.replace(/\.json$/, '')}`;
 
   if (!vendor || !packageFile) {
     return c.json({ error: 'Bad Request', message: 'Invalid package name' }, 400);
@@ -351,6 +357,8 @@ export async function p2PackageRoute(c: Context<ComposerRouteEnv>): Promise<Resp
   const kvKey = `p2:${packageName}`;
   const metadataKey = `p2:${packageName}:metadata`;
   const db = c.get('database');
+  const requestUrl = new URL(c.req.url);
+  const requestBaseUrl = `${requestUrl.protocol}//${requestUrl.host}`;
 
   // Check conditional request
   const ifModifiedSince = c.req.header('If-Modified-Since');
@@ -433,19 +441,42 @@ export async function p2PackageRoute(c: Context<ComposerRouteEnv>): Promise<Resp
   if (existingPackages.length > 0) {
     // Build response from database packages
     const maxVersions = getMaxVersions(c.env);
-    const url = new URL(c.req.url);
-    const baseUrl = `${url.protocol}//${url.host}`;
-    const packageData = buildP2Response(packageName, existingPackages, maxVersions, baseUrl);
+    const packageData = buildP2Response(packageName, existingPackages, maxVersions, requestBaseUrl);
 
     // Cache the result (fire-and-forget to avoid blocking on KV rate limits)
+    // TTL keeps cached responses from outliving the revalidation window
     const cachingEnabled = await isPackageCachingEnabled(c.env.KV);
     if (cachingEnabled && c.env.KV) {
-      runInBackground(c,
-        Promise.all([
-          c.env.KV.put(kvKey, JSON.stringify(packageData)).catch(() => { }),
-          c.env.KV.put(metadataKey, JSON.stringify({ lastModified: Date.now() })).catch(() => { })
-        ])
-      );
+      const kv = c.env.KV;
+      // Stale-while-revalidate: this branch is only reached when the cached
+      // response has expired (at most once per TTL), so it doubles as the
+      // trigger to re-check upstream for new releases. The cache write MUST
+      // complete before revalidation runs - otherwise revalidation's cache
+      // purge could be overwritten by this stale response.
+      // Pinned to the repos the rows came from - see package-revalidation.ts.
+      const repoIds = [...new Set<string>(existingPackages.map((pkg: typeof packages.$inferSelect) => pkg.repo_id))];
+      runInBackground(c, (async () => {
+        await Promise.all([
+          kv.put(kvKey, JSON.stringify(packageData), { expirationTtl: REVALIDATION_TTL_SECONDS }).catch(() => { }),
+          kv.put(metadataKey, JSON.stringify({ lastModified: Date.now() }), { expirationTtl: REVALIDATION_TTL_SECONDS }).catch(() => { })
+        ]);
+        await revalidateStalePackage({
+          db,
+          cache: kv,
+          packageName,
+          repoIds,
+          encryptionKey: c.env.ENCRYPTION_KEY,
+          proxyBaseUrl: requestBaseUrl,
+          loadPackageFromRepo: fetchPackageFromRepository,
+          storePackages: transformPackageDistUrls,
+        });
+      })().catch((error) => {
+        const logger = getLogger();
+        logger.warn('Background package revalidation failed', {
+          packageName,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }));
     }
 
     // Track metadata request (cache miss, from DB)
@@ -468,8 +499,6 @@ export async function p2PackageRoute(c: Context<ComposerRouteEnv>): Promise<Resp
   }
 
   // Not in database - try lazy loading from upstream repositories
-  const url = new URL(c.req.url);
-  const baseUrl = `${url.protocol}//${url.host}`;
   const maxVersions = getMaxVersions(c.env);
 
   const lazyLoadResult = await lazyLoadPackageFromRepositories(
@@ -481,10 +510,10 @@ export async function p2PackageRoute(c: Context<ComposerRouteEnv>): Promise<Resp
 
   if (lazyLoadResult) {
     const { packageData, repoId } = lazyLoadResult;
-    const transformedData = transformDistUrlsInMemory(packageData, repoId, baseUrl, maxVersions);
+    const transformedData = transformDistUrlsInMemory(packageData, repoId, requestBaseUrl, maxVersions);
 
     // Store package versions in background
-    schedulePackageStorage(c, packageName, packageData, repoId, baseUrl);
+    schedulePackageStorage(c, packageName, packageData, repoId, requestBaseUrl);
 
     // Track metadata request (cache miss, from upstream)
     const analytics = getAnalytics();
@@ -983,23 +1012,51 @@ export async function ensurePackagistRepository(
 }
 
 
+/** A repo stuck in 'syncing' longer than this is treated as dead (killed worker) */
+const STALE_SYNC_THRESHOLD_SECONDS = 900;
+
 /**
- * Sync all pending repositories
- * Uses job processor which automatically chooses sync vs async execution
- * @returns true if any repositories were synced
+ * Sync all pending repositories in the background.
+ * Uses job processor which automatically chooses sync vs async execution.
+ * @returns true while any repository sync is pending or still running -
+ *          callers must not cache packages.json built in that window
  */
 async function syncPendingRepositories(c: Context<ComposerRouteEnv>): Promise<boolean> {
   const db = c.get('database');
 
-  // Get repositories that need sync (pending status)
-  const reposToSync = await db
+  const unsettledRepos = await db
     .select()
     .from(repositories)
-    .where(eq(repositories.status, 'pending'));
+    .where(inArray(repositories.status, ['pending', 'syncing']));
+
+  const now = Math.floor(Date.now() / 1000);
+  const isStaleSync = (repo: any) =>
+    repo.status === 'syncing' && (repo.last_synced_at || 0) <= now - STALE_SYNC_THRESHOLD_SECONDS;
+
+  // Re-sync repos stuck in 'syncing' (worker killed mid-sync) along with
+  // pending ones - otherwise they would stay unsynced forever
+  const reposToSync = unsettledRepos.filter(
+    (repo: any) => repo.status === 'pending' || isStaleSync(repo)
+  );
+  const syncsInFlight = unsettledRepos.filter(
+    (repo: any) => repo.status === 'syncing' && !isStaleSync(repo)
+  );
 
   if (reposToSync.length === 0) {
-    return false;
+    return syncsInFlight.length > 0;
   }
+
+  // Claim the repos before backgrounding the sync so concurrent
+  // packages.json requests do not start duplicate syncs of the same repo
+  await db
+    .update(repositories)
+    .set({ status: 'syncing', last_synced_at: now })
+    .where(
+      and(
+        inArray(repositories.id, reposToSync.map((repo: any) => repo.id)),
+        inArray(repositories.status, ['pending', 'syncing'])
+      )
+    );
 
   // Determine proxy base URL from request
   const url = new URL(c.req.url);
@@ -1027,8 +1084,12 @@ async function syncPendingRepositories(c: Context<ComposerRouteEnv>): Promise<bo
     repoId: repo.id,
   }));
 
-  // Process all jobs (parallel for sync, queued for async)
-  await jobProcessor.enqueueAll(syncJobs);
+  // Run syncs in the background: inline sync of a large repository would
+  // otherwise block the packages.json response until every repo finishes
+  runInBackground(c, jobProcessor.enqueueAll(syncJobs).catch((error) => {
+    const logger = getLogger();
+    logger.error('Background repository sync failed', {}, error instanceof Error ? error : new Error(String(error)));
+  }));
 
   return true;
 }

--- a/packages/core/src/routes/package-revalidation.ts
+++ b/packages/core/src/routes/package-revalidation.ts
@@ -1,0 +1,119 @@
+/*
+ * PACKAGE.broker
+ * Copyright (C) 2025 Łukasz Bajsarowicz
+ * Licensed under AGPL-3.0
+ */
+
+// Stale-while-revalidate for package metadata served from the database.
+//
+// Once a package is stored in D1, the p2 route serves it from the database
+// and never contacts upstream again. Without revalidation, new upstream
+// releases (e.g. a Magento security patch) are invisible forever. This module
+// re-fetches upstream metadata in the background while the stale copy keeps
+// being served.
+//
+// Rate limiting is structural, not marker-based: the route only triggers
+// revalidation on the DB-served path, which is reached at most once per
+// cached-response TTL (the KV entry written by that same path). An in-memory
+// set dedupes concurrent triggers within an isolate, and a content hash
+// stored in KV skips the D1 upsert entirely when upstream did not change.
+
+import type { DatabasePort } from '../ports';
+import { repositories } from '../db/schema';
+import { inArray } from 'drizzle-orm';
+import { getLogger } from '../utils/logger';
+import type { fetchPackageFromRepository, transformPackageDistUrls } from './composer';
+
+/** How long a cached p2 response lives — doubles as the revalidation cadence. */
+export const REVALIDATION_TTL_SECONDS = 3600;
+
+/**
+ * Minimal cache surface needed for revalidation. Structurally satisfied by
+ * Cloudflare KVNamespace and by CachePort implementations (Redis, memory),
+ * keeping this module platform-neutral per the core architecture rules.
+ */
+export interface RevalidationCache {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+export interface RevalidationDeps {
+  db: DatabasePort;
+  cache: RevalidationCache;
+  packageName: string;
+  /** Repositories the stored rows came from — revalidation is pinned to them
+   * so a refresh can never migrate versions to a different repo_id
+   * (cross-repo collisions, see issue #99). */
+  repoIds: string[];
+  encryptionKey: string;
+  proxyBaseUrl: string;
+  /** Injected type-safely from routes/composer.ts (type-only import avoids a runtime cycle) */
+  loadPackageFromRepo: typeof fetchPackageFromRepository;
+  storePackages: typeof transformPackageDistUrls;
+}
+
+/** Dedupe concurrent revalidations of the same package within this isolate */
+const inFlight = new Set<string>();
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Re-fetch package metadata from the repositories it was originally stored
+ * from, and refresh the database only when the upstream content changed.
+ * On change, the cached p2 response is purged so the next request rebuilds
+ * from the refreshed rows.
+ */
+export async function revalidateStalePackage(deps: RevalidationDeps): Promise<void> {
+  const { db, cache, packageName, repoIds, encryptionKey, proxyBaseUrl } = deps;
+
+  if (inFlight.has(packageName)) {
+    return;
+  }
+  inFlight.add(packageName);
+
+  try {
+    const repos = repoIds.length > 0
+      ? await db.select().from(repositories).where(inArray(repositories.id, repoIds))
+      : [];
+
+    let changed = false;
+
+    for (const repo of repos) {
+      const packageData = await deps.loadPackageFromRepo(repo, packageName, encryptionKey);
+      if (!packageData) {
+        continue; // Upstream has no data (removed or unreachable) — keep serving stored rows
+      }
+
+      // Skip the D1 upsert when upstream content is byte-identical to the
+      // last stored fetch — revalidating unchanged packages must not burn
+      // the D1 write budget.
+      const hashKey = `p2:${packageName}:${repo.id}:content-hash`;
+      const contentHash = await sha256Hex(JSON.stringify(packageData));
+      const previousHash = await cache.get(hashKey);
+      if (previousHash === contentHash) {
+        continue;
+      }
+
+      await deps.storePackages(packageData, repo.id, proxyBaseUrl, db);
+      await cache.put(hashKey, contentHash);
+      changed = true;
+    }
+
+    if (changed) {
+      // Purge the cached response so the next request rebuilds from refreshed rows
+      await Promise.all([
+        cache.delete(`p2:${packageName}`),
+        cache.delete(`p2:${packageName}:metadata`),
+      ]);
+
+      const logger = getLogger();
+      logger.info('Revalidated package metadata from upstream', { packageName, repoIds });
+    }
+  } finally {
+    inFlight.delete(packageName);
+  }
+}

--- a/packages/core/src/utils/upstream-fetch.ts
+++ b/packages/core/src/utils/upstream-fetch.ts
@@ -349,22 +349,57 @@ async function fetchFromIncludes(
  * @param packageName - Package name to fetch (e.g., "weltpixel/magento2-weltpixel-social-login")
  * @param encryptionKey - Key for decrypting credentials
  */
+/**
+ * Extract owner and repository name from a GitHub URL (https or ssh form).
+ * Linear scan equivalent of /github\.com[:\/]([^\/]+)\/([^\/.]+)/ without
+ * the polynomial backtracking CodeQL flags on attacker-influenced input.
+ * The repo name stops at the first '.' or '/' (drops the '.git' suffix).
+ */
+export function parseGitHubOwnerRepo(url: string): { owner: string; repoName: string } | null {
+  const host = 'github.com';
+  const hostIndex = url.indexOf(host);
+  if (hostIndex === -1) {
+    return null;
+  }
+
+  const separator = url[hostIndex + host.length];
+  if (separator !== ':' && separator !== '/') {
+    return null;
+  }
+
+  const rest = url.slice(hostIndex + host.length + 1);
+  const slashIndex = rest.indexOf('/');
+  if (slashIndex <= 0) {
+    return null;
+  }
+
+  const owner = rest.slice(0, slashIndex);
+  const afterOwner = rest.slice(slashIndex + 1);
+
+  let end = 0;
+  while (end < afterOwner.length && afterOwner[end] !== '/' && afterOwner[end] !== '.') {
+    end++;
+  }
+  const repoName = afterOwner.slice(0, end);
+
+  return repoName.length > 0 ? { owner, repoName } : null;
+}
+
 export async function fetchPackageFromGitHub(
   repo: UpstreamRepository,
   packageName: string,
   encryptionKey: string
 ): Promise<ProviderPackageResponse | null> {
   const logger = getLogger();
-  
-  // Parse GitHub URL
-  const urlMatch = repo.url.match(/github\.com[:/]([^/]+)\/([^/.]+)/);
-  if (!urlMatch) {
+
+  // Parse GitHub URL (explicit scan - avoids regex backtracking on untrusted input)
+  const parsed = parseGitHubOwnerRepo(repo.url);
+  if (!parsed) {
     logger.warn('Invalid GitHub URL format', { url: repo.url });
     return null;
   }
-  
-  const [, owner, repoName] = urlMatch;
-  const cleanRepoName = repoName.replace('.git', '');
+
+  const { owner, repoName: cleanRepoName } = parsed;
   
   // Get token (null for public repos with 'none' credential type)
   let token: string | null = null;

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -12,6 +12,8 @@ import {
   initAnalytics,
   PackageStorageWorkflow,
   createApp,
+  processQueueMessage,
+  type QueueMessage,
 } from '@package-broker/core';
 import { R2Driver } from './adapters/r2-storage.js';
 import { createD1Database } from './adapters/d1-database.js';
@@ -165,5 +167,31 @@ export default {
 
     const app = createWorker({ storage: 'r2' }, env);
     return app.fetch(request, env, ctx);
+  },
+
+  /**
+   * Queue consumer for async database updates (token usage, artifact
+   * download counters, repository sync status). Without this handler,
+   * queued messages are never consumed and silently expire.
+   */
+  async queue(batch: MessageBatch<QueueMessage>, env: Env): Promise<void> {
+    const logLevel = (env?.LOG_LEVEL || 'info') as 'debug' | 'info' | 'warn' | 'error';
+    const logger = getLogger(logLevel);
+
+    await Promise.all(
+      batch.messages.map(async (msg) => {
+        try {
+          await processQueueMessage(msg.body, { DB: env.DB });
+          msg.ack();
+        } catch (error) {
+          logger.error(
+            'Error processing queue message',
+            { messageType: msg.body?.type },
+            error instanceof Error ? error : new Error(String(error))
+          );
+          msg.retry();
+        }
+      })
+    );
   },
 };

--- a/packages/main/wrangler.example.toml
+++ b/packages/main/wrangler.example.toml
@@ -51,6 +51,7 @@ queue = "package-broker-queue"
 queue = "package-broker-queue"
 max_batch_size = 10
 max_batch_timeout = 30
+max_retries = 3
 
 # Analytics Engine (OPTIONAL - free tier: 100k events/day)
 # Analytics Engine datasets are automatically created on first write.

--- a/wrangler.dev.toml
+++ b/wrangler.dev.toml
@@ -40,3 +40,4 @@ queue = "package-broker-queue"
 queue = "package-broker-queue"
 max_batch_size = 10
 max_batch_timeout = 30
+max_retries = 3

--- a/wrangler.example.toml
+++ b/wrangler.example.toml
@@ -51,6 +51,7 @@ queue = "package-broker-queue"
 queue = "package-broker-queue"
 max_batch_size = 10
 max_batch_timeout = 30
+max_retries = 3
 
 # Analytics Engine (OPTIONAL - free tier: 100k events/day)
 # Analytics Engine datasets are automatically created on first write.


### PR DESCRIPTION
## Problem

Production deployments with a Queue producer bound silently lost every repository sync:

1. **Sync jobs vanished.** `createJobProcessor` sent `sync_repository` jobs to the Cloudflare Queue whenever `QUEUE` was bound, but the worker exported no `queue()` handler and the consumer wasn't configured — 1 producer, 0 consumers. Jobs expired unprocessed; repositories stayed `pending` forever.
2. **Stale-forever metadata.** `p2PackageRoute` serves from D1 whenever any rows exist for a package and only contacts upstream for unknown packages. Once stored, a package's version list froze permanently — new upstream releases (e.g. `magento/product-community-edition` 2.4.7-p10, a security patch) were invisible, failing `composer update` with "found [...] but it does not match the constraint".
3. **Immortal caches.** KV `p2:*` entries were written without TTL.

## Fix

**Sync execution**
- `sync_repository` jobs now always run inline: they need request-scoped context (storage driver, proxy base URL) that a queue consumer does not have. Other jobs (token usage, artifact counters) still use the queue, and the main worker now exports a `queue()` handler for them; the dead, never-wired consumer default export in core is removed. Consumer config templates get `max_retries = 3`.
- Pending repos are **claimed** (`pending` → `syncing`) in the request path before the sync is backgrounded, so concurrent `packages.json` requests cannot start duplicate full syncs. Repos stuck in `syncing` for >15 min (worker killed mid-sync) are re-claimed and retried.
- `packages.json` is never cached while syncs are pending or in flight — previously the route could pin a pre-sync package list in KV with no TTL.

**Stale-while-revalidate for p2 metadata** (new `routes/package-revalidation.ts`)
- Cached p2 responses now expire after 1h. The DB-served path (reached at most once per TTL by construction) serves the stored data immediately and re-fetches upstream in the background.
- Revalidation is **pinned to the repos the stored rows came from**, so a refresh can never migrate versions to a different `repo_id` (avoids reopening #99).
- A content hash (SHA-256 of the upstream payload, kept in KV) skips the D1 upsert entirely when upstream did not change — no write amplification for static packages.
- The cache write is chained before revalidation in one background task so revalidation's cache purge cannot be overwritten by the stale response.
- The module is platform-neutral (`RevalidationCache` interface + type-only imports), per the core no-Cloudflare-types rule.

**Drive-by**
- p2 package-name parsing strips only the trailing `.json` (names containing `.json` were corrupted).

## Why this approach

Running syncs in the queue consumer would need the storage driver and proxy base URL reconstructed from env plus payload — doable, but the sync already runs fine inline under `waitUntil`, and the claim-before-background pattern fixes the duplicate-sync stampede that existed regardless of transport. Revalidation deliberately has no marker key: the response-cache TTL is the natural rate limiter, an in-isolate in-flight set dedupes bursts, and the content hash gates writes — fewer KV ops than a marker while avoiding its non-atomicity and failure-suppression problems.

## Security impact

- Queue consumer changes touch no auth paths; messages are internal job payloads only.
- Known pre-existing limitation (unchanged by this PR, now recurring hourly instead of once): stored proxy dist URLs derive from the request Host header. `buildP2Response` prefers original upstream metadata dist, so exposure is limited to fallback URLs. A canonical-base-URL setting is the proper fix — follow-up.

## Test plan

- New unit tests: revalidation (repo-pinned fetch, content-hash skip, in-flight dedupe, no-op on missing upstream), job routing (inline sync vs queued lightweight jobs, mixed batches), p2 route (KV TTL + chained revalidation scheduling).
- `npm test` — 252 passed. `npm run typecheck` — clean. `npm run build` — clean. E2E mocked — 24 passed, 1 pre-existing flake (passes in isolation on main and on this branch).

## Deploy notes

Deployments with a Queue producer must also enable the consumer (already uncommented in the config templates):

```toml
[[queues.consumers]]
queue = "package-broker-queue"
max_batch_size = 10
max_batch_timeout = 30
max_retries = 3
```