### PR TITLE
fix(core): fetch full Packagist metadata

### DIFF
--- a/packages/core/src/__tests__/upstream-fetch.test.ts
+++ b/packages/core/src/__tests__/upstream-fetch.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchPackageFromUpstream } from '../utils/upstream-fetch';
+
+vi.mock('../utils/encryption', () => ({
+  decryptCredentials: vi.fn().mockResolvedValue('{}'),
+}));
+
+describe('fetchPackageFromUpstream', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches full package metadata for Packagist packages', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        package: {
+          versions: {
+            'v6.4.31': {
+              name: 'symfony/console',
+              version: 'v6.4.31',
+              autoload: {
+                'psr-4': {
+                  'Symfony\\Component\\Console\\': '',
+                },
+              },
+              require: {
+                php: '>=8.1',
+              },
+              dist: {
+                type: 'zip',
+                url: 'https://api.github.com/repos/symfony/console/zipball/ref',
+              },
+            },
+          },
+        },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchPackageFromUpstream(
+      {
+        id: 'packagist',
+        url: 'https://repo.packagist.org',
+        vcs_type: 'composer',
+        credential_type: 'none',
+        auth_credentials: '{}',
+      },
+      'symfony/console',
+      'key'
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://packagist.org/packages/symfony/console.json',
+      expect.any(Object)
+    );
+    expect(result?.packages['symfony/console']['v6.4.31'].autoload).toEqual({
+      'psr-4': {
+        'Symfony\\Component\\Console\\': '',
+      },
+    });
+  });
+});

--- a/packages/core/src/modules/packages/packages.handlers.ts
+++ b/packages/core/src/modules/packages/packages.handlers.ts
@@ -10,7 +10,6 @@ import { buildStorageKey, buildReadmeStorageKey, buildChangelogStorageKey } from
 import { downloadFromSource } from '../../utils/download';
 import { decryptCredentials } from '../../utils/encryption';
 import { nanoid } from 'nanoid';
-import { COMPOSER_USER_AGENT } from '@package-broker/shared';
 import { isPackagistMirroringEnabled } from '../admin';
 import { getLogger } from '../../utils/logger';
 import { extractReadme, extractChangelog } from '../../utils/zip-utils';
@@ -723,23 +722,23 @@ export async function addPackagesFromMirror(c: Context<PackagesRouteEnv>): Promi
     // Fetch each package from Packagist
     for (const packageName of body.package_names) {
       try {
-        const packagistUrl = `https://repo.packagist.org/p2/${packageName}.json`;
-        const response = await fetch(packagistUrl, {
-          headers: {
-            'User-Agent': COMPOSER_USER_AGENT,
+        const packageData = await fetchPackageFromUpstream(
+          {
+            id: 'packagist',
+            url: 'https://repo.packagist.org',
+            vcs_type: 'composer',
+            credential_type: 'none',
+            auth_credentials: '{}',
           },
-        });
+          packageName,
+          c.env.ENCRYPTION_KEY
+        );
 
-        if (!response.ok) {
-          if (response.status === 404) {
-            results.push({ package: packageName, success: false, error: 'Package not found' });
-            continue;
-          }
-          results.push({ package: packageName, success: false, error: `HTTP ${response.status}` });
+        if (!packageData) {
+          results.push({ package: packageName, success: false, error: 'Package not found' });
           continue;
         }
 
-        const packageData: any = await response.json();
         const { transformPackageDistUrls } = await import('../composer');
         const { storedCount, errors } = await transformPackageDistUrls(packageData, 'packagist', baseUrl, db);
 

--- a/packages/core/src/routes/composer.ts
+++ b/packages/core/src/routes/composer.ts
@@ -13,7 +13,6 @@ import { eq, and, inArray } from 'drizzle-orm';
 import { createJobProcessor, type Job } from '../jobs/processor';
 import type { StorageDriver } from '../storage/driver';
 import { isPackagistMirroringEnabled, isPackageCachingEnabled } from '../modules/admin';
-import { COMPOSER_USER_AGENT } from '@package-broker/shared';
 import { nanoid } from 'nanoid';
 import { encryptCredentials } from '../utils/encryption';
 import { getLogger } from '../utils/logger';
@@ -316,15 +315,10 @@ export async function lazyLoadPackageFromRepositories(
   if (mirroringEnabled) {
     try {
       await ensurePackagistRepository(db, encryptionKey, kv || undefined);
-      const packagistUrl = `https://repo.packagist.org/p2/${packageName}.json`;
-      const response = await fetch(packagistUrl, {
-        headers: {
-          'User-Agent': COMPOSER_USER_AGENT,
-        },
-      });
-      
-      if (response.ok) {
-        const packageData = await response.json();
+      const { fetchFullPackageFromPackagist } = await import('../utils/upstream-fetch');
+      const packageData = await fetchFullPackageFromPackagist(packageName);
+
+      if (packageData) {
         return { packageData, repoId: 'packagist' };
       }
     } catch (error) {

--- a/packages/core/src/utils/upstream-fetch.ts
+++ b/packages/core/src/utils/upstream-fetch.ts
@@ -126,6 +126,10 @@ export async function fetchPackageFromUpstream(
   );
   
   const baseUrl = repo.url.replace(/\/$/, '');
+
+  if (baseUrl === 'https://repo.packagist.org') {
+    return fetchFullPackageFromPackagist(packageName);
+  }
   
   // First, get packages.json to understand repository structure
   const packagesJsonUrl = `${baseUrl}/packages.json`;
@@ -199,6 +203,42 @@ export async function fetchPackageFromUpstream(
   }
   
   return null;
+}
+
+export async function fetchFullPackageFromPackagist(
+  packageName: string
+): Promise<ProviderPackageResponse | null> {
+  const response = await pRetry(
+    () =>
+      fetch(`https://packagist.org/packages/${packageName}.json`, {
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': COMPOSER_USER_AGENT,
+        },
+      }),
+    { retries: 2 }
+  );
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const packageData = await response.json() as {
+    package?: {
+      versions?: Record<string, ComposerPackage>;
+    };
+  };
+  const versions = packageData.package?.versions;
+
+  if (!versions || Object.keys(versions).length === 0) {
+    return null;
+  }
+
+  return {
+    packages: {
+      [packageName]: versions,
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fetch Packagist packages from the full package API so stored metadata includes autoload and require fields
- Reuse that path for lazy public mirroring and manual Packagist imports
- Add coverage for symfony/console metadata preserving PSR-4 autoload

## Verification
- npx vitest run packages/core/src/__tests__/upstream-fetch.test.ts packages/core/src/__tests__/composer-route.test.ts
- npm run typecheck -w packages/core